### PR TITLE
sstar: yaml key's correction for extended hw info on stock fw

### DIFF
--- a/src/vendors/sstar.c
+++ b/src/vendors/sstar.c
@@ -8,6 +8,12 @@
 #include <string.h>
 #include <unistd.h>
 
+typedef enum fmt_option_e {
+    str_none = 0,
+    str_rtrim = (1<<0),
+    str_kebab_case = (1<<1),
+} fmt_option_t;
+
 static void strrtrim(char *str) {
     char *s = str;
     if (!str || !strlen(str))
@@ -17,15 +23,30 @@ static void strrtrim(char *str) {
         *s-- = 0;
 }
 
-static void append_board_param(char *fname, char *dst, char *fmt, int rtrim) {
+static void str_kebab(char *str)
+{
+    if(!str || !strlen(str))
+        return;
+    char *s = str;
+    while(*s) {
+        *s=tolower(*s);
+        if(*s == '_')
+            *s = '-';
+        s++;
+    }
+}
+
+static void append_board_param(char *fname, char *dst, char *fmt, fmt_option_t fmt_option) {
     char buf[255];
     FILE *fp = NULL;
     if (!access(fname, R_OK)) {
         if (fp = fopen(fname, "rb")) {
             memset(buf, 0, sizeof(buf));
             if (fread(buf, 1, sizeof(buf), fp) > 0) {
-                if (rtrim)
+                if (fmt_option & str_rtrim)
                     strrtrim(buf);
+                if (fmt_option & str_kebab_case)
+                    str_kebab(buf);
                 sprintf(dst + strlen(dst), fmt, buf);
             }
             fclose(fp);
@@ -34,12 +55,12 @@ static void append_board_param(char *fname, char *dst, char *fmt, int rtrim) {
 }
 
 void gather_sstar_board_info() {
-    append_board_param("/sys/devices/soc0/machine", board_id, "%s", 1);
-    append_board_param("/sys/class/mstar/msys/CHIP_ID", board_specific, "  %s", 0);
-    append_board_param("/sys/class/mstar/msys/CHIP_VERSION", board_specific, "  %s", 0);
-    append_board_param("/sys/devices/soc0/family", board_specific, "  SoC_Family:%s", 0);
-    append_board_param("/sys/devices/soc0/soc_id", board_specific, "  SoC_Id:%s", 0);
-    append_board_param("/sys/devices/soc0/revision", board_specific, "  SoC_Revision:%s", 0);
+    append_board_param("/sys/devices/soc0/machine", board_id, "%s", str_rtrim);
+    append_board_param("/sys/class/mstar/msys/CHIP_ID", board_specific, "  %s", str_kebab_case);
+    append_board_param("/sys/class/mstar/msys/CHIP_VERSION", board_specific, "  %s", str_kebab_case);
+    append_board_param("/sys/devices/soc0/family", board_specific, "  soc-family: %s", 0);
+    append_board_param("/sys/devices/soc0/soc_id", board_specific, "  soc-id: %s", 0);
+    append_board_param("/sys/devices/soc0/revision", board_specific, "  soc-revision: %s", 0);
 }
 
 bool is_sstar_board() {


### PR DESCRIPTION
small correction to previous patch
result
```
---
board:
  model: INFINITY6B0 SSC009A-S01A QFN88
  chip-id: 0xf2
  chip-version: 1
  soc-family: I6B0
  soc-id: 242
  soc-revision: 2
chip:
  vendor: SStar
  ...
```