### PR TITLE
readme: add TP-Link NC210 to the tested list

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -224,7 +224,7 @@ Tested on:
 
 |Manufacturer|Models|
 |---|---|
-|[HiSilicon](https://github.com/openIPC/camerasrnd/#chip-families-information)|Hi3516CV100/200/300, Hi3516EV100/200/300, Hi3516DV300|
+|[HiSilicon](https://github.com/openIPC/camerasrnd/#chip-families-information)|Hi3516CV100/200/300, Hi3516EV100/200/300, Hi3516DV300, Hi3518EV100|
 |[SigmaStar](http://linux-chenxing.org/)|SSC335|
 |[Xiongmai](http://www.xiongmaitech.com/product)|XM510, XM530, XM550|
 
@@ -239,6 +239,7 @@ Tested on:
 |Xiongmai| Various models |
 |Hankvision | V6202IR-IMX327 |
 |Ruision | RS-H649F-A0, RS-H651JAI-AO, RS-H656S-AO |
+|TP-Link | NC210 |
 
 ## Supported sensors
 


### PR DESCRIPTION
So I have this camera from ToiletPaper-Link with silly firmware that [only offers h264 over HTTP (!), no RTSP or RTMP or anything like that](https://github.com/reald/nc220/pull/17/files).

The UART just has a root shell :) and the busybox has a "wget", so it was easy to run this:


```yaml
---
chip:
  vendor: HiSilicon
  model: 3518EV100
ethernet:
  mac: "50:c7:bf:05:xx:xx"
  u-mdio-phyaddr: 1
  phy-id: 0x0000ffff
  d-mdio-phyaddr: 0
  phy-mode: mii
rom:
  - type: nor
    block: 64K
    partitions:
      - name: uboot
        size: 0x40000
        sha1: 8d4871a9
      - name: RF
        size: 0x10000
        sha1: f4b904fb
      - name: Config
        size: 0x10000
        sha1: 369ab61a
      - name: IPCConfig
        size: 0x100000
        path: /usr/local/config/ipcamera,jffs2,rw
      - name: kernel
        size: 0x280000
        sha1: 9b33305e
      - name: rootfs
        size: 0xc20000
        path: /,jffs2
        sha1: 0e34c1b3
    size: 16M
    addr-mode: 3-byte
ram:
  total: 64M
  media: 24M
firmware:
  kernel: "3.0.8 (Tue Mar 29 11:52:40 CST 2016)"
  toolchain: gcc version 4.4.1 (Hisilicon_v100(gcc4.4-290+uclibc_0.9.32.1+eabi+linuxpthread))
  libc: uClibc 0.9.32.1
  sdk: "Hi3518_MPP_V1.0.9.0  (Aug 27 2014, 22:11:58)"
  god-app: streamd
sensors:
- vendor: OmniVision
  model: OV9712
  control:
    bus: 0
    type: i2c
    addr: 0x60
  data:
    type: DC
  clock: 24MHz
```

The model of the flash chip was not detected here but it's a winbond W25Q128B. For Wi-Fi it uses a Mediatek MT7601 (usb 148f:7601).