### PR TITLE
Change regex for cpu detection

### DIFF
--- a/src/chipid.c
+++ b/src/chipid.c
@@ -49,7 +49,7 @@ static const manufacturers_t manufacturers[] = {
     {"SStar", sstar_detect_cpu, NULL, sstar_setup_hal},
     {"MStar", mstar_detect_cpu, NULL, sstar_setup_hal},
     {"Novatek", novatek_detect_cpu, NULL, novatek_setup_hal},
-    {"Grain-Media", gm_detect_cpu, NULL, gm_setup_hal},
+    {"Grain", gm_detect_cpu, NULL, gm_setup_hal},
     {"FH", fh_detect_cpu, "Fullhan", fh_setup_hal},
     {NULL /* Generic */, rockchip_detect_cpu, "Rockchip", rockchip_setup_hal},
     {"Xilinx", xilinx_detect_cpu, NULL, xilinx_setup_hal},
@@ -65,11 +65,9 @@ static bool generic_detect_cpu() {
     char buf[256] = "unknown";
 
     strcpy(chip_name, "unknown");
-    bool res = line_from_file("/proc/cpuinfo", "Hardware\t+: ([a-zA-Z-]+)",
-                              buf, sizeof(buf));
+    bool res = line_from_file("/proc/cpuinfo", "Hardware.+:.(\\w+)", buf, sizeof(buf));
     if (!res) {
-        res = line_from_file("/proc/cpuinfo", "vendor_id\t+: (.+)", buf,
-                             sizeof(buf));
+        res = line_from_file("/proc/cpuinfo", "vendor_id.+:.(\\w+)", buf, sizeof(buf));
     }
     strcpy(chip_manufacturer, buf);
 


### PR DESCRIPTION
Updated from #55

Samples for `Hardware.+:.(\w+)`
- [SStar](https://regex101.com/r/GKOiME/1)
- [Grain](https://regex101.com/r/UZteK2/1)
- [Goke](https://regex101.com/r/b8YRB5/1)
- [isvp](https://regex101.com/r/bDOK7m/1)
- [hi3516a](https://regex101.com/r/4L5bqv/1)
- [xm530](https://regex101.com/r/sdMbxG/1)
- [Freescale](https://regex101.com/r/R8SZIF/1)
- [Marvell](https://regex101.com/r/2juwfo/1)

Samples for `vendor_id.+:.(\w+)`
- [AuthenticAMD](https://regex101.com/r/cTz25J/1)
- [GenuineIntel](https://regex101.com/r/kHl6C9/1)

Test from board:
```
root@openipc-ssc338q:/tmp# ./ipctool
---
chip:
  vendor: SStar
  model: id 0xf1
board:
  vendor: OpenIPC
  version: 2.3.03.27
```