### PR TITLE
Only sum nor/nand type mtd partitions

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -211,7 +211,8 @@ static bool cb_mtd_info(int i, const char *name, struct mtd_info_user *mtd,
             }
         }
     }
-    c->totalsz += mtd->size;
+    if (mtd->type == MTD_NORFLASH || mtd->type == MTD_NANDFLASH)
+        c->totalsz += mtd->size;
     return true;
 }
 


### PR DESCRIPTION
Skip the partition size of any ram partition type.