### PR TITLE
Add alternative telnet upload script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ C library to work on vast majority of hardware.
      46% |**************                 | 61952   0:00:01 ETA
   ```
 
+* *Using telnet/console only*: uses a python script to transfer ipctool via
+  telnet/echo to the camera:
+  ```
+  wget https://github.com/OpenIPC/ipctool/releases/download/latest/ipctool
+  od -An -tx1 ipctool | sed 's/ /\\x/g' > ipctool.hex
+  tools/telnet_upload.py --host 192.168.1.10 --user root --password 12345 ipctool.hex
+  ```
+
 ## Usage
 
 ```console

--- a/tools/telnet_upload.py
+++ b/tools/telnet_upload.py
@@ -1,0 +1,33 @@
+#!/bin/python3
+
+import argparse
+import telnetlib
+
+argparser = argparse.ArgumentParser()
+argparser.add_argument('--host', required=True)
+argparser.add_argument('--port', type=int, default=23)
+argparser.add_argument('--user', type=str, default="root")
+argparser.add_argument('--password', type=str, default="12345")
+argparser.add_argument('src')
+args = argparser.parse_args()
+
+print("Connect to: " + args.host)
+t = telnetlib.Telnet(args.host, args.port)
+
+t.read_until(b"login")
+t.write(args.user.encode() + b"\n")
+
+t.read_until(b"Password")
+t.write(args.password.encode() + b"\n")
+
+payload = open(args.src, 'rb')
+payload_lines = payload.readlines()
+
+t.write(b"cd /tmp\n")
+t.write(b"rm -f ipctool\n")
+
+for line in payload_lines:
+  t.write(b"echo -ne '" + line.strip() + b"' >> ipctool\n")
+
+t.write(b"chmod 755 ipctool\n")
+t.mt_interact()


### PR DESCRIPTION
This commit expands from pull request #40, which i think is an interesting idea.

- Example usage:
```
wget https://github.com/OpenIPC/ipctool/releases/download/latest/ipctool
base64 ipctool > ipctool.b64
tools/base64_upload.py --host 192.168.1.10 --user root --password 12345 ipctool.b64
```

The script doesn't countercheck the telnet credentials, so that needs to be verified prior executing.
Or can be added/extended on a later time.