### PR TITLE
minor refactoring / add sdk codenames

### DIFF
--- a/src/chipid.c
+++ b/src/chipid.c
@@ -19,18 +19,17 @@
 
 int chip_generation;
 char chip_name[128];
-static char chip_manufacturer[128];
 char nor_chip[128];
+static char chip_manufacturer[128];
 
 static long get_uart0_address() {
     char buf[256];
 
-    bool res = line_from_file("/proc/iomem",
-                              "^([0-9a-f]+)-[0-9a-f]+ : .*uart[@:][0-9]", buf,
-                              sizeof(buf));
-    if (!res) {
+    if (!line_from_file("/proc/iomem", "^(\\w+)-.+:.+uart",
+                buf, sizeof(buf))) {
         return -1;
     }
+
     return strtol(buf, NULL, 16);
 }
 
@@ -47,10 +46,10 @@ static const manufacturers_t manufacturers[] = {
     {"ingenic", ingenic_detect_cpu, "Ingenic", setup_hal_ingenic},
 #endif
 #ifdef __arm__
-    {"SStar", sstar_detect_cpu, NULL, sstar_setup_hal},
+    {"SStar", sstar_detect_cpu, "SigmaStar", sstar_setup_hal},
     {"MStar", mstar_detect_cpu, NULL, sstar_setup_hal},
     {"Novatek", novatek_detect_cpu, NULL, novatek_setup_hal},
-    {"Grain", gm_detect_cpu, NULL, gm_setup_hal},
+    {"Grain", gm_detect_cpu, "GrainMedia", gm_setup_hal},
     {"FH", fh_detect_cpu, "Fullhan", fh_setup_hal},
     {NULL /* Generic */, rockchip_detect_cpu, "Rockchip", rockchip_setup_hal},
     {"Xilinx", xilinx_detect_cpu, NULL, xilinx_setup_hal},

--- a/src/hal/sstar.c
+++ b/src/hal/sstar.c
@@ -112,19 +112,15 @@ static int sstar_open_sensor_fd() {
     return universal_open_sensor_fd("/dev/i2c-1");
 }
 
-static int sstar_i2c_write(int fd, unsigned char slave_addr,
-            unsigned char *reg_addr, unsigned char reg_width) {
-    unsigned int data_size = reg_width * sizeof(unsigned char);
-    return 0;
-}
-
 static void sstar_hal_cleanup() {
+    //
 }
 
 static float sstar_get_temp() {
     char buf[16];
 
-    if (!line_from_file(TEMP_PATH, "Temperature\\s+(.+)", buf, sizeof(buf))) {
+    if (!line_from_file(TEMP_PATH, "Temperature.(.+)",
+                buf, sizeof(buf))) {
         return 0;
     }
 
@@ -134,7 +130,8 @@ static float sstar_get_temp() {
 static unsigned long sstar_media_mem() {
     char buf[256];
 
-    if (!line_from_file(CMD_PATH, "mma_heap=.+sz=(\\w+)", buf,sizeof(buf))) {
+    if (!line_from_file(CMD_PATH, "mma_heap=.+sz=(\\w+)",
+                buf, sizeof(buf))) {
         return 0;
     }
 

--- a/src/hal/sstar.h
+++ b/src/hal/sstar.h
@@ -11,14 +11,14 @@
 #define MSTAR_ADDR 0x1F2025A4
 #define SSTAR_ADDR 0x1F003C00
 
-#define INFINITY3  0xC2
-#define INFINITY5  0xED
-#define MERCURY5   0xEE
-#define INFINITY6  0xEF
-#define INFINITY2M 0xF0
-#define INFINITY6E 0xF1
-#define INFINITY6B 0xF2
-#define PIONEER3   0xF5
+#define INFINITY3  0xC2 // Twinkie
+#define INFINITY5  0xED // Pretzel
+#define MERCURY5   0xEE // Mercury5
+#define INFINITY6  0xEF // Macaron
+#define INFINITY2M 0xF0 // Taiyaki
+#define INFINITY6E 0xF1 // Pudding
+#define INFINITY6B 0xF2 // Ispahan
+#define PIONEER3   0xF5 // Ikayaki
 
 bool mstar_detect_cpu(char *chip_name);
 bool sstar_detect_cpu(char *chip_name);


### PR DESCRIPTION
Changes:
- adds the proper vendor names for SigmaStar and GrainMedia
- adds the sigmastar sdk codenames
- changes the regex for get_uart0_address (this needs to be verified):
  - [`^([0-9a-f]+)-[0-9a-f]+ : .*uart[@:][0-9]`](https://regex101.com/r/rfsip9/1)
  - [`^(\w+)-.+:.+uart`](https://regex101.com/r/1E8qZ1/1)

Edit:
Output from a HI3516EV300:
```
/tmp # ./ipctool
--- debug: 0x12040000
---
chip:
  vendor: HiSilicon
  model: 3516EV300
```