### PR TITLE
Makes firmware uploads to the cloud explicit.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,13 @@ set(IPCTOOL_SRC
     src/boards/sstar.h
     ${VERSION_SRC})
 
+set(CYAML_TEST_SRC
+    src/cjson/cYAML_test.c
+    src/cjson/cJSON.c
+    src/cjson/cJSON.h
+    src/cjson/cYAML.c
+    src/cjson/cYAML.h)
+
 add_library(ipchw STATIC ${COMMON_LIB_SRC})
 target_compile_definitions(ipchw PUBLIC STANDALONE_LIBRARY)
 target_link_libraries(ipchw m)
@@ -153,4 +160,6 @@ if(NOT ONLY_LIBRARY)
   target_include_directories(ipcinfo PUBLIC include)
   target_link_libraries(ipcinfo ipchw)
   install(TARGETS ipcinfo RUNTIME DESTINATION /usr/bin/)
+
+  add_executable(cYAML_test ${CYAML_TEST_SRC})
 endif()

--- a/src/backup.h
+++ b/src/backup.h
@@ -1,9 +1,7 @@
 #ifndef BACKUP_H
 #define BACKUP_H
 
-bool udp_lock();
-int do_backup(const char *yaml, size_t yaml_len, bool wait_mode,
-              const char *filename);
+int do_backup(const char *yaml, size_t yaml_len, const char *filename);
 int upgrade_restore_cmd(int argc, char **argv);
 
 #endif /* BACKUP_H */

--- a/src/boards/common.c
+++ b/src/boards/common.c
@@ -36,9 +36,7 @@ static const board_vendors_t vendors[] = {
 };
 
 cJSON *detect_board() {
-    cJSON *fake_root = cJSON_CreateObject();
     cJSON *j_inner = cJSON_CreateObject();
-    cJSON_AddItemToObject(fake_root, "board", j_inner);
 
     for (size_t i = 0; i < ARRCNT(vendors); i++) {
         if (vendors[i].detector_fn())
@@ -52,5 +50,5 @@ cJSON *detect_board() {
         ADD_PARAM("possible-IR-cut-GPIO", ircuts);
     }
 
-    return fake_root;
+    return j_inner;
 }

--- a/src/boards/sstar.c
+++ b/src/boards/sstar.c
@@ -50,7 +50,7 @@ static void append_board_param(cJSON *j_inner, char *fname, char *param,
                     strrtrim(buf);
 
                 if (fmt_option & str_ltrim)
-                    ADD_PARAM(param, strltrim(buf))
+                    ADD_PARAM(param, strltrim(buf));
                 else
                     ADD_PARAM(param, buf);
             }

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -216,15 +216,13 @@ const char *getchipvendor() {
 
 #ifndef STANDALONE_LIBRARY
 cJSON *detect_chip() {
-    cJSON *fake_root = cJSON_CreateObject();
     cJSON *j_inner = cJSON_CreateObject();
-    cJSON_AddItemToObject(fake_root, "chip", j_inner);
 
     ADD_PARAM("vendor", chip_manufacturer);
     ADD_PARAM("model", chip_name);
     if (hal_chip_properties)
         hal_chip_properties(j_inner);
 
-    return fake_root;
+    return j_inner;
 }
 #endif

--- a/src/cjson/cYAML.c
+++ b/src/cjson/cYAML.c
@@ -169,7 +169,6 @@ static bool print_number(string_buffer *buf, double d) {
 }
 
 static bool do_indent(string_buffer *buf, int depth, int dashes, bool in_list) {
-    if (depth <= 0) return true;
 
     /* In the YAML 1.2.2 spec, top-level lists, and lists one level below the
      * top are both rendered with the dash in column 0. */
@@ -279,7 +278,12 @@ CJSON_PUBLIC(char *) cYAML_Print(const cJSON *item) {
     if (!buf) return NULL;
 
     if (!strbuf_push(buf, "---\n")) goto bail;
-    if (!print_value(buf, item, 0, 0, false)) goto bail;
+
+    /* Hack to correctly print top-level lists. */
+    int depth = 0;
+    if ((item->type & 0xFF) == cJSON_Array) depth = 1;
+
+    if (!print_value(buf, item, depth, 0, false)) goto bail;
 
     ret = strdup(buf->data);
 

--- a/src/cjson/cYAML.c
+++ b/src/cjson/cYAML.c
@@ -5,610 +5,281 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h>
 
 #include "cJSON.h"
 #include "cYAML.h"
 
-#define internal_malloc malloc
-#define internal_free free
-#define internal_realloc realloc
 
-typedef struct internal_hooks {
-    void *(CJSON_CDECL *allocate)(size_t size);
-    void(CJSON_CDECL *deallocate)(void *pointer);
-    void *(CJSON_CDECL *reallocate)(void *pointer, size_t size);
-} internal_hooks;
+#define TRY(op)                     \
+    do {                            \
+        if (!(op)) return false;    \
+    } while(0)
 
-static internal_hooks global_hooks = {internal_malloc, internal_free,
-                                      internal_realloc};
 
-typedef struct {
-    unsigned char *buffer;
-    size_t length;
-    size_t offset;
-    size_t depth; /* current nesting depth (for formatted printing) */
-    cJSON_bool noalloc;
-    cJSON_bool format; /* is this print a formatted print */
-    internal_hooks hooks;
-    cJSON_bool next_dash;
-} printbuffer;
+typedef struct string_buffer {
+    char *data;
+    size_t len;
+    size_t cap;
+} string_buffer;
 
-#define cjson_min(a, b) (((a) < (b)) ? (a) : (b))
 
-#define EXTEND_OUT_TO(length)                                                  \
-    output_pointer = ensure(output_buffer, length);                            \
-    if (output_pointer == NULL) {                                              \
-        return false;                                                          \
-    }
+static bool print_value(string_buffer *buf, const cJSON *item, int depth, int dashes);
 
-#define OUT_CHAR(c)                                                            \
-    *output_pointer++ = c;                                                     \
-    output_buffer->offset++
 
-/* calculate the new length of the string in a printbuffer and update the offset
- */
-static void update_offset(printbuffer *const buffer) {
-    const unsigned char *buffer_pointer = NULL;
-    if ((buffer == NULL) || (buffer->buffer == NULL)) {
-        return;
-    }
-    buffer_pointer = buffer->buffer + buffer->offset;
+static string_buffer *strbuf_new() {
+    string_buffer *buf = calloc(1, sizeof(string_buffer));
+    if (!buf) return NULL;
 
-    buffer->offset += strlen((const char *)buffer_pointer);
+    buf->cap = 256;
+    buf->data = calloc(buf->cap, sizeof(char));
+    if (!buf->data) goto bail;
+
+    return buf;
+
+bail:
+    free(buf);
+    return NULL;
 }
 
-/* realloc printbuffer if necessary to have at least "needed" bytes more */
-static unsigned char *ensure(printbuffer *const p, size_t needed) {
-    unsigned char *newbuffer = NULL;
-    size_t newsize = 0;
-
-    if ((p == NULL) || (p->buffer == NULL)) {
-        return NULL;
-    }
-
-    if ((p->length > 0) && (p->offset >= p->length)) {
-        /* make sure that offset is valid */
-        return NULL;
-    }
-
-    if (needed > INT_MAX) {
-        /* sizes bigger than INT_MAX are currently not supported */
-        return NULL;
-    }
-
-    needed += p->offset + 1;
-    if (needed <= p->length) {
-        return p->buffer + p->offset;
-    }
-
-    if (p->noalloc) {
-        return NULL;
-    }
-
-    /* calculate new buffer size */
-    if (needed > (INT_MAX / 2)) {
-        /* overflow of int, use INT_MAX if possible */
-        if (needed <= INT_MAX) {
-            newsize = INT_MAX;
-        } else {
-            return NULL;
-        }
-    } else {
-        newsize = needed * 2;
-    }
-
-    if (p->hooks.reallocate != NULL) {
-        /* reallocate with realloc if available */
-        newbuffer = (unsigned char *)p->hooks.reallocate(p->buffer, newsize);
-        if (newbuffer == NULL) {
-            p->hooks.deallocate(p->buffer);
-            p->length = 0;
-            p->buffer = NULL;
-
-            return NULL;
-        }
-    } else {
-        /* otherwise reallocate manually */
-        newbuffer = (unsigned char *)p->hooks.allocate(newsize);
-        if (!newbuffer) {
-            p->hooks.deallocate(p->buffer);
-            p->length = 0;
-            p->buffer = NULL;
-
-            return NULL;
-        }
-        if (newbuffer) {
-            memcpy(newbuffer, p->buffer, p->offset + 1);
-        }
-        p->hooks.deallocate(p->buffer);
-    }
-    p->length = newsize;
-    p->buffer = newbuffer;
-
-    return newbuffer + p->offset;
+static void strbuf_free(string_buffer *buf) {
+    free(buf->data);
+    free(buf);
 }
 
-/* get the decimal point character of the current locale */
-static unsigned char get_decimal_point(void) {
+static bool strbuf_expand(string_buffer *buf, size_t need_cap) {
+    /* Make sure to at least double the buffer. */
+    if (need_cap < buf->cap) need_cap = buf->cap;
+
+    char *data = realloc(buf->data, need_cap * 2);
+    TRY(data);
+
+    buf->data = data;
+    buf->cap = need_cap * 2;
+
+    return true;
+}
+
+static bool strbuf_push(string_buffer *buf, const char *s) {
+    size_t s_len = strlen(s);
+
+    if (buf->len + s_len + 1 > buf->cap) {
+        TRY(strbuf_expand(buf, s_len + 1));
+    }
+    strcpy(buf->data + buf->len, s);
+    buf->len += s_len;
+
+    return true;
+}
+
+static bool print_string(string_buffer *buf, const char *s) {
+    if (!s) {
+        TRY(strbuf_push(buf, "\"\""));
+        return true;
+    }
+
+    static const char *ESCAPES = "\"\\\b\f\n\r\t";
+    static const char *REPLACEMENTS = "\"\\bfnrt";
+
+    bool needs_escaping = false;
+    for (const char *c = s; *c; c++) {
+        if (*c < 32 || *c == ':' || index(ESCAPES, *c) != NULL) {
+            needs_escaping = true;
+            break;
+        }
+    }
+
+    if (!needs_escaping) {
+        TRY(strbuf_push(buf, s));
+        return true;
+    }
+
+    TRY(strbuf_push(buf, "\""));
+    for (const char *c = s; *c; c++) {
+        char *found = index(ESCAPES, *c);
+        if (found != NULL) {
+            char repl[] = "\\_";
+            repl[1] = REPLACEMENTS[found - ESCAPES];
+            TRY(strbuf_push(buf, repl));
+            continue;
+        }
+
+        if (*c < 32) {
+            /* Expand non-printable characters. */
+            char repl[10];
+            TRY(snprintf(repl, sizeof(repl), "\\u%04x", *c) < sizeof(repl));
+            TRY(strbuf_push(buf, repl));
+            continue;
+        }
+
+        char repl[] = "_";
+        repl[0] = *c;
+        TRY(strbuf_push(buf, repl));
+    }
+    TRY(strbuf_push(buf, "\""));
+
+    return true;
+}
+
+/* Get the decimal point character of the current locale. */
+static char get_decimal_point(void) {
 #ifdef ENABLE_LOCALES
     struct lconv *lconv = localeconv();
-    return (unsigned char)lconv->decimal_point[0];
+    return (char)lconv->decimal_point[0];
 #else
     return '.';
 #endif
 }
 
-/* securely comparison of floating-point variables */
-static cJSON_bool compare_double(double a, double b) {
+/* Securely compare floating-point variables. */
+static bool compare_double(double a, double b) {
     double maxVal = fabs(a) > fabs(b) ? fabs(a) : fabs(b);
     return (fabs(a - b) <= maxVal * DBL_EPSILON);
 }
 
-/* Render the number nicely from the given item into a string. */
-static cJSON_bool print_number(const cJSON *const item,
-                               printbuffer *const output_buffer) {
-    unsigned char *output_pointer = NULL;
-    double d = item->valuedouble;
-    int length = 0;
-    size_t i = 0;
-    unsigned char number_buffer[26] = {
-        0}; /* temporary buffer to print the number into */
-    unsigned char decimal_point = get_decimal_point();
-    double test = 0.0;
-
-    if (output_buffer == NULL) {
-        return false;
-    }
-
-    /* This checks for NaN and Infinity */
+static bool print_number(string_buffer *buf, double d) {
+    /* Handle NaN and Infinity. */
     if (isnan(d) || isinf(d)) {
-        length = sprintf((char *)number_buffer, "null");
-    } else {
-        /* Try 15 decimal places of precision to avoid nonsignificant nonzero
-         * digits */
-        length = sprintf((char *)number_buffer, "%1.15g", d);
-
-        /* Check whether the original double can be recovered */
-        if ((sscanf((char *)number_buffer, "%lg", &test) != 1) ||
-            !compare_double((double)test, d)) {
-            /* If not, print with 17 decimal places of precision */
-            length = sprintf((char *)number_buffer, "%1.17g", d);
-        }
-    }
-
-    /* sprintf failed or buffer overrun occurred */
-    if ((length < 0) || (length > (int)(sizeof(number_buffer) - 1))) {
-        return false;
-    }
-
-    /* reserve appropriate space in the output */
-    output_pointer = ensure(output_buffer, (size_t)length + sizeof(""));
-    if (output_pointer == NULL) {
-        return false;
-    }
-
-    /* copy the printed number to the output and replace locale
-     * dependent decimal point with '.' */
-    for (i = 0; i < ((size_t)length); i++) {
-        if (number_buffer[i] == decimal_point) {
-            output_pointer[i] = '.';
-            continue;
-        }
-
-        output_pointer[i] = number_buffer[i];
-    }
-    output_pointer[i] = '\0';
-
-    output_buffer->offset += (size_t)length;
-
-    return true;
-}
-
-static bool do_ident(bool trigger, printbuffer *const output_buffer) {
-    unsigned char *output = NULL;
-
-    if (trigger && output_buffer->depth) {
-        size_t ident = (output_buffer->depth - 1) * 2;
-        output = ensure(output_buffer, ident);
-        if (output == NULL) {
-            return false;
-        }
-        for (size_t i = 0; i < ident; i++) {
-            char space = ' ';
-            if (output_buffer->next_dash && i == ident - 2) {
-                space = '-';
-                output_buffer->next_dash = false;
-            }
-            *output++ = space;
-        }
-        output_buffer->offset += ident;
-    }
-    return true;
-}
-
-/* Render the cstring provided to an escaped version that can be printed. */
-static cJSON_bool print_string_ptr(const unsigned char *const input,
-                                   printbuffer *const output_buffer,
-                                   bool is_value) {
-    const unsigned char *input_pointer = NULL;
-    unsigned char *output_pointer = NULL;
-    size_t output_length = 0;
-    /* numbers of additional characters needed for escaping */
-    size_t escape_characters = 0;
-
-    if (output_buffer == NULL) {
-        return false;
-    }
-
-    unsigned char *output = NULL;
-    /* empty string */
-    if (input == NULL) {
-        const char *qstr = "\"\"";
-        output = ensure(output_buffer, strlen(qstr));
-        if (output == NULL) {
-            return false;
-        }
-        strcpy((char *)output, qstr);
-
+        TRY(strbuf_push(buf, "null"));
         return true;
     }
 
-    bool need_quotes = false;
+    char tmp[26];
+    /* Try 15 decimal places to avoid nonsignificant nonzero digits. */
+    TRY(snprintf(tmp, sizeof(tmp), "%1.15g", d) < sizeof(tmp));
 
-    /* set "flag" to 1 if something needs to be escaped */
-    for (input_pointer = input; *input_pointer; input_pointer++) {
-        switch (*input_pointer) {
-        case '\"':
-        case '\\':
-        case '\b':
-        case '\f':
-        case '\n':
-        case '\r':
-        case '\t':
-            /* one character escape sequence */
-            escape_characters++;
-            break;
-        case ':':
-            need_quotes = true;
-            break;
-        default:
-            if (*input_pointer < 32) {
-                /* UTF-16 escape sequence uXXXX */
-                escape_characters += 3;
-            }
+    /* Check whether the original double can be recovered. */
+    double test = 0.0;
+    if ((sscanf(tmp, "%lg", &test) != 1) || !compare_double(test, d)) {
+        /* If not, print with 17 decimal places of precision. */
+        TRY(snprintf(tmp, sizeof(tmp), "%1.17g", d) < sizeof(tmp));
+    }
+
+    /* Replace locale dependent decimal point with '.'. */
+    char decimal_point = get_decimal_point();
+    for (char *c = tmp; *c; c++) {
+        if (*c == decimal_point) {
+            *c = '.';
             break;
         }
     }
-    output_length = (size_t)(input_pointer - input) + escape_characters;
-
-    output = ensure(output_buffer, output_length + 2);
-    if (output == NULL) {
-        return false;
-    }
-
-    /* no characters have to be escaped */
-    if (!need_quotes && escape_characters == 0) {
-        memcpy(output, input, output_length);
-        output[output_length] = '\0';
-
-        return true;
-    }
-
-    output_pointer = output;
-    *output_pointer++ = '\"';
-    /* copy the string */
-    for (input_pointer = input; *input_pointer != '\0';
-         (void)input_pointer++, output_pointer++) {
-        if ((*input_pointer > 31) && (*input_pointer != '\"') &&
-            (*input_pointer != '\\')) {
-            /* normal character, copy */
-            *output_pointer = *input_pointer;
-        } else {
-            /* character needs to be escaped */
-            *output_pointer++ = '\\';
-            switch (*input_pointer) {
-            case '\\':
-                *output_pointer = '\\';
-                break;
-            case '\"':
-                *output_pointer = '\"';
-                break;
-            case '\b':
-                *output_pointer = 'b';
-                break;
-            case '\f':
-                *output_pointer = 'f';
-                break;
-            case '\n':
-                *output_pointer = 'n';
-                break;
-            case '\r':
-                *output_pointer = 'r';
-                break;
-            case '\t':
-                *output_pointer = 't';
-                break;
-            default:
-                /* escape and print as unicode codepoint */
-                sprintf((char *)output_pointer, "u%04x", *input_pointer);
-                output_pointer += 4;
-                break;
-            }
-        }
-    }
-    *output_pointer++ = '\"';
-    *output_pointer = '\0';
+    TRY(strbuf_push(buf, tmp));
 
     return true;
 }
 
-/* Invoke print_string_ptr (which is useful) on an item. */
-static cJSON_bool print_string(const cJSON *const item, printbuffer *const p) {
-    return print_string_ptr((unsigned char *)item->valuestring, p, true);
-}
+static bool do_indent(string_buffer *buf, int depth, int dashes) {
+    if (depth <= 0) return true;
 
-static cJSON_bool print_value(const cJSON *const item,
-                              printbuffer *const output_buffer, bool newlined);
-
-static bool print_item(cJSON *current_item, unsigned char *output_pointer,
-                       printbuffer *const output_buffer) {
-    if (!do_ident(true, output_buffer))
-        return false;
-
-    int type = current_item->type & 0xFF;
-    if (current_item->string) {
-        /* print key */
-        if (!print_string_ptr((unsigned char *)current_item->string,
-                              output_buffer, false)) {
-            return false;
-        }
-        update_offset(output_buffer);
-
-        EXTEND_OUT_TO(2);
-        OUT_CHAR(':');
-
-        switch (type) {
-        case cJSON_Array:
-        case cJSON_Object:
-            OUT_CHAR('\n');
-            break;
-        default:
-            OUT_CHAR(' ');
-        }
-    } else if (!output_buffer->next_dash && type == cJSON_Array) {
-        EXTEND_OUT_TO(1);
-        OUT_CHAR('\n');
+    int i = 0;
+    for (; i < depth - dashes; i++) {
+        TRY(strbuf_push(buf, "  "));
     }
-
-    if (!print_value(current_item, output_buffer, true)) {
-        return false;
+    for (; i < depth; i++) {
+        TRY(strbuf_push(buf, "- "));
     }
-
-    update_offset(output_buffer);
 
     return true;
 }
 
-/* Render an array to text */
-static cJSON_bool print_array(const cJSON *const item,
-                              printbuffer *const output_buffer) {
-    unsigned char *output_pointer = NULL;
-    size_t length = 0;
-    cJSON *current_element = item->child;
+static bool print_key_value(string_buffer *buf, const cJSON *item, int depth, int dashes) {
+    TRY(item->string);
 
-    if (output_buffer == NULL) {
-        return false;
-    }
+    TRY(do_indent(buf, depth, dashes));
 
-    /* Compose the output array. */
-    length = 0;
-    output_pointer = ensure(output_buffer, length + 1);
-    if (output_pointer == NULL) {
-        return false;
-    }
+    /* print the key */
+    TRY(print_string(buf, item->string));
+    TRY(strbuf_push(buf, ":"));
 
-    bool ident = true;
-    int type = current_element->type & 0xFF;
-    if (type == cJSON_Object) {
-        ident = false;
+    switch (item->type & 0xFF) {
+    case cJSON_Object:
+    case cJSON_Array:
+        TRY(strbuf_push(buf, "\n"));
+        TRY(print_value(buf, item, depth + 1, dashes));
+        break;
+    default:
+        TRY(strbuf_push(buf, " "));
+        TRY(print_value(buf, item, 0, 0));
     }
-
-    if (ident)
-        output_buffer->depth++;
-    output_buffer->offset += length;
-
-    while (current_element != NULL) {
-        output_buffer->next_dash = true;
-        if (!print_item(current_element, output_pointer, output_buffer))
-            return false;
-        update_offset(output_buffer);
-        current_element = current_element->next;
-    }
-
-    output_pointer = ensure(output_buffer, 2);
-    if (output_pointer == NULL) {
-        return false;
-    }
-    if (ident) {
-        output_buffer->depth--;
-    }
-    *output_pointer = '\0';
 
     return true;
 }
 
-/* Render an object to text. */
-static cJSON_bool print_object(const cJSON *const item,
-                               printbuffer *const output_buffer) {
-    if (output_buffer == NULL) {
-        return false;
+static bool print_object(string_buffer *buf, const cJSON *item, int depth, int dashes) {
+    cJSON *it = item->child;
+
+    while (it) {
+        TRY(print_key_value(buf, it, depth, dashes));
+        dashes = 0;
+        it = it->next;
     }
-
-    cJSON *current_item = item->child;
-
-    /* Compose the output: */
-    unsigned char *output_pointer;
-    EXTEND_OUT_TO(0);
-
-    output_buffer->depth++;
-
-    while (current_item) {
-        if (!print_item(current_item, output_pointer, output_buffer))
-            return false;
-        current_item = current_item->next;
-    }
-
-    EXTEND_OUT_TO(1);
-    *output_pointer = '\0';
-    output_buffer->depth--;
 
     return true;
 }
 
-static bool print_value_aux(const cJSON *const item,
-                            printbuffer *const output_buffer,
-                            unsigned char *output) {
+static bool print_array(string_buffer *buf, const cJSON *item, int depth, int dashes) {
+    cJSON *it = item->child;
+
+    while (it) {
+        TRY(print_value(buf, it, depth + 1, dashes + 1));
+        dashes = 0;
+        it = it->next;
+    }
+
+    return true;
+}
+
+static bool print_value(string_buffer *buf, const cJSON *item, int depth, int dashes) {
     switch ((item->type) & 0xFF) {
     case cJSON_NULL:
-        output = ensure(output_buffer, 5);
-        if (output == NULL) {
-            return false;
-        }
-        strcpy((char *)output, "null");
-        return true;
+        TRY(do_indent(buf, depth, dashes));
+        return strbuf_push(buf, "null\n");
 
     case cJSON_False:
-        output = ensure(output_buffer, 6);
-        if (output == NULL) {
-            return false;
-        }
-        strcpy((char *)output, "false");
-        return true;
+        TRY(do_indent(buf, depth, dashes));
+        return strbuf_push(buf, "false\n");
 
     case cJSON_True:
-        output = ensure(output_buffer, 5);
-        if (output == NULL) {
-            return false;
-        }
-        strcpy((char *)output, "true");
-        return true;
+        TRY(do_indent(buf, depth, dashes));
+        return strbuf_push(buf, "true\n");
 
     case cJSON_Number:
-        return print_number(item, output_buffer);
-
-    case cJSON_Raw: {
-        size_t raw_length = 0;
-        if (item->valuestring == NULL) {
-            return false;
-        }
-
-        raw_length = strlen(item->valuestring) + sizeof("");
-        output = ensure(output_buffer, raw_length);
-        if (output == NULL) {
-            return false;
-        }
-        memcpy(output, item->valuestring, raw_length);
-        return true;
-    }
+        TRY(do_indent(buf, depth, dashes));
+        TRY(print_number(buf, item->valuedouble));
+        return strbuf_push(buf, "\n");
 
     case cJSON_String:
-        return print_string(item, output_buffer);
+        TRY(do_indent(buf, depth, dashes));
+        TRY(print_string(buf, item->valuestring));
+        return strbuf_push(buf, "\n");
 
     case cJSON_Array:
-        return print_array(item, output_buffer);
+        return print_array(buf, item, depth, dashes);
 
     case cJSON_Object:
-        return print_object(item, output_buffer);
+        return print_object(buf, item, depth, dashes);
+
+    case cJSON_Raw:
+        TRY(item->valuestring);
+        return strbuf_push(buf, item->valuestring);
 
     default:
         return false;
     }
 }
 
-/* Render a value to text. */
-static cJSON_bool print_value(const cJSON *const item,
-                              printbuffer *const output_buffer, bool newlined) {
-    unsigned char *output = NULL;
-
-    if ((item == NULL) || (output_buffer == NULL)) {
-        return false;
-    }
-
-    if (!print_value_aux(item, output_buffer, output))
-        return false;
-    update_offset(output_buffer);
-
-    if (newlined) {
-        if (output_buffer->buffer[output_buffer->offset - 1] != '\n') {
-            unsigned char *output_pointer;
-            EXTEND_OUT_TO(1);
-            OUT_CHAR('\n');
-            *output_pointer++ = '\0';
-        }
-    }
-
-    return true;
-}
-
-static unsigned char *print(const cJSON *const item, cJSON_bool format,
-                            const internal_hooks *const hooks) {
-    static const size_t default_buffer_size = 256;
-    printbuffer buffer[1];
-    unsigned char *printed = NULL;
-
-    memset(buffer, 0, sizeof(buffer));
-
-    /* create buffer */
-    buffer->buffer = (unsigned char *)hooks->allocate(default_buffer_size);
-    buffer->length = default_buffer_size;
-    buffer->format = format;
-    buffer->hooks = *hooks;
-    if (buffer->buffer == NULL) {
-        goto fail;
-    }
-
-    /* print the value */
-    if (!print_value(item, buffer, false)) {
-        goto fail;
-    }
-    update_offset(buffer);
-
-    /* check if reallocate is available */
-    if (hooks->reallocate != NULL) {
-        printed = (unsigned char *)hooks->reallocate(buffer->buffer,
-                                                     buffer->offset + 1);
-        if (printed == NULL) {
-            goto fail;
-        }
-        buffer->buffer = NULL;
-    } else /* otherwise copy the JSON over to a new buffer */
-    {
-        printed = (unsigned char *)hooks->allocate(buffer->offset + 1);
-        if (printed == NULL) {
-            goto fail;
-        }
-        memcpy(printed, buffer->buffer,
-               cjson_min(buffer->length, buffer->offset + 1));
-        printed[buffer->offset] = '\0'; /* just to be sure */
-
-        /* free the buffer */
-        hooks->deallocate(buffer->buffer);
-    }
-
-    return printed;
-
-fail:
-    if (buffer->buffer != NULL) {
-        hooks->deallocate(buffer->buffer);
-    }
-
-    if (printed != NULL) {
-        hooks->deallocate(printed);
-    }
-
-    return NULL;
-}
-
 CJSON_PUBLIC(char *) cYAML_Print(const cJSON *item) {
-    return (char *)print(item, true, &global_hooks);
+    char *ret = NULL;
+
+    string_buffer *buf = strbuf_new();
+    if (!buf) return NULL;
+
+    if (!strbuf_push(buf, "---\n")) goto bail;
+    if (!print_value(buf, item, 0, 0)) goto bail;
+
+    ret = strdup(buf->data);
+
+bail:
+    strbuf_free(buf);
+    return ret;
 }

--- a/src/cjson/cYAML_test.c
+++ b/src/cjson/cYAML_test.c
@@ -6,75 +6,117 @@
 #include "cjson/cYAML.h"
 #include "tools.h"
 
-int main(int argc, char *argv[]) {
-    cJSON *root = cJSON_Parse("{ "
-        "  \"rom\": {"
-        "    \"attr\": \"val\","
-        "    \"other\": 1.6"
-        "  },"
-        "  \"ram\": {"
-        "    \"size\": 4096,"
-        "    \"name\": \"mRA\bM\""
-        "  },"
-        "  \"list\" : ["
-        "   \"item1\","
-        "   \"item2\","
-        "   ["
-        "       \"sub1\","
-        "       \"sub2\""
-        "   ],"
-        "   \"item3\","
-        "   ["
-        "       [ \"subsub1\" ],"
-        "       [ 1, 2, { \"val\": 3, \"spelled\": \"three\" }, 4 ],"
-        "       [ \"subsub3\" ]"
-        "   ],"
-        "   \"item4\""
-        "  ]"
-        "}");
+bool run_test(const char *name, const char *json, const char *wanted) {
+    bool ret = false;
+    cJSON *root = cJSON_Parse(json);
     if (!root) {
-        fprintf(stderr, "Parse error\n");
-        return 1;
+        fprintf(stderr, "\nERROR: Could not parse JSON:\n%s\n", json);
+        goto bail1;
     }
-
-    const char *wanted =
-        "---\n"
-        "rom:\n"
-        "  attr: val\n"
-        "  other: 1.6\n"
-        "ram:\n"
-        "  size: 4096\n"
-        "  name: \"mRA\\bM\"\n"
-        "list:\n"
-        "- item1\n"
-        "- item2\n"
-        "- - sub1\n"
-        "  - sub2\n"
-        "- item3\n"
-        "- - - subsub1\n"
-        "  - - 1\n"
-        "    - 2\n"
-        "    - val: 3\n"
-        "      spelled: three\n"
-        "    - 4\n"
-        "  - - subsub3\n"
-        "- item4\n";
-
     char *got = cYAML_Print(root);
     if (!got) {
-        fprintf(stderr, "cYAML_Print() returned NULL.\n");
-        return 2;
+        fprintf(stderr, "\nERROR: cYAML_Print() returned NULL.\n");
+        goto bail2;
     }
     if (strcmp(wanted, got) != 0) {
-        fprintf(stderr, "Unexpected YAML ouput.\nWanted:\n%s\nGot:\n%s\n\nFAILED\n", wanted, got);
-        return 3;
+        fprintf(stderr, "\nERROR: Unexpected YAML ouput.\nWanted:\n%s\nGot:\n%s\n", wanted, got);
+        goto bail3;
     }
+    ret = true;
 
-    printf("%s\n\n", got);
-    fprintf(stderr, "PASSED\n");
-
+bail3:
     free(got);
+bail2:
     cJSON_Delete(root);
+bail1:
+    fprintf(stderr, "\nTest %s: %s\n", name, ret ? "PASSED" : "FAILED");
+    return ret;
+}
 
+int main(int argc, char *argv[]) {
+    run_test("top-level object",
+
+             "{ "
+             "  \"rom\": {"
+             "    \"attr\": \"val\","
+             "    \"other\": 1.6"
+             "  },"
+             "  \"ram\": {"
+             "    \"size\": 4096,"
+             "    \"name\": \"mRA\bM\""
+             "  },"
+             "  \"list\" : ["
+             "   \"item1\","
+             "   \"item2\","
+             "   ["
+             "       \"sub1\","
+             "       \"sub2\""
+             "   ],"
+             "   \"item3\","
+             "   ["
+             "       [ \"subsub1\" ],"
+             "       [ 1, 2, { \"val\": 3, \"spelled\": \"three\" }, 4 ],"
+             "       [ \"subsub3\" ]"
+             "   ],"
+             "   \"item4\""
+             "  ]"
+             "}",
+
+             "---\n"
+             "rom:\n"
+             "  attr: val\n"
+             "  other: 1.6\n"
+             "ram:\n"
+             "  size: 4096\n"
+             "  name: \"mRA\\bM\"\n"
+             "list:\n"
+             "- item1\n"
+             "- item2\n"
+             "- - sub1\n"
+             "  - sub2\n"
+             "- item3\n"
+             "- - - subsub1\n"
+             "  - - 1\n"
+             "    - 2\n"
+             "    - val: 3\n"
+             "      spelled: three\n"
+             "    - 4\n"
+             "  - - subsub3\n"
+             "- item4\n"
+             );
+
+    run_test("top-level list",
+
+             "["
+             " \"item1\","
+             " \"item2\","
+             " ["
+             "     \"sub1\","
+             "     \"sub2\""
+             " ],"
+             " \"item3\","
+             " ["
+             "     [ \"subsub1\" ],"
+             "     [ 1, 2, { \"val\": 3, \"spelled\": \"three\" }, 4 ],"
+             "     [ \"subsub3\" ]"
+             " ],"
+             " \"item4\""
+             "]",
+
+             "---\n"
+             "- item1\n"
+             "- item2\n"
+             "- - sub1\n"
+             "  - sub2\n"
+             "- item3\n"
+             "- - - subsub1\n"
+             "  - - 1\n"
+             "    - 2\n"
+             "    - val: 3\n"
+             "      spelled: three\n"
+             "    - 4\n"
+             "  - - subsub3\n"
+             "- item4\n"
+             );
     return 0;
 }

--- a/src/cjson/cYAML_test.c
+++ b/src/cjson/cYAML_test.c
@@ -1,0 +1,80 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "cjson/cJSON.h"
+#include "cjson/cYAML.h"
+#include "tools.h"
+
+int main(int argc, char *argv[]) {
+    cJSON *root = cJSON_Parse("{ "
+        "  \"rom\": {"
+        "    \"attr\": \"val\","
+        "    \"other\": 1.6"
+        "  },"
+        "  \"ram\": {"
+        "    \"size\": 4096,"
+        "    \"name\": \"mRA\bM\""
+        "  },"
+        "  \"list\" : ["
+        "   \"item1\","
+        "   \"item2\","
+        "   ["
+        "       \"sub1\","
+        "       \"sub2\""
+        "   ],"
+        "   \"item3\","
+        "   ["
+        "       [ \"subsub1\" ],"
+        "       [ 1, 2, { \"val\": 3, \"spelled\": \"three\" }, 4 ],"
+        "       [ \"subsub3\" ]"
+        "   ],"
+        "   \"item4\""
+        "  ]"
+        "}");
+    if (!root) {
+        fprintf(stderr, "Parse error\n");
+        return 1;
+    }
+
+    const char *wanted =
+        "---\n"
+        "rom:\n"
+        "  attr: val\n"
+        "  other: 1.6\n"
+        "ram:\n"
+        "  size: 4096\n"
+        "  name: \"mRA\\bM\"\n"
+        "list:\n"
+        "  - item1\n"
+        "  - item2\n"
+        "  - - sub1\n"
+        "    - sub2\n"
+        "  - item3\n"
+        "  - - - subsub1\n"
+        "    - - 1\n"
+        "      - 2\n"
+        "      - val: 3\n"
+        "        spelled: three\n"
+        "      - 4\n"
+        "    - - subsub3\n"
+        "  - item4\n";
+
+    char *got = cYAML_Print(root);
+    if (!got) {
+        fprintf(stderr, "cYAML_Print() returned NULL.\n");
+        return 2;
+    }
+    if (strcmp(wanted, got) != 0) {
+        fprintf(stderr, "Unexpected YAML ouput.\nWanted:\n%s\nGot:\n%s\n\nFAILED\n", wanted, got);
+        return 3;
+    }
+
+    printf("%s\n\n", got);
+    fprintf(stderr, "PASSED\n");
+
+    free(got);
+    cJSON_Delete(root);
+
+    return 0;
+}

--- a/src/cjson/cYAML_test.c
+++ b/src/cjson/cYAML_test.c
@@ -46,19 +46,19 @@ int main(int argc, char *argv[]) {
         "  size: 4096\n"
         "  name: \"mRA\\bM\"\n"
         "list:\n"
-        "  - item1\n"
-        "  - item2\n"
-        "  - - sub1\n"
-        "    - sub2\n"
-        "  - item3\n"
-        "  - - - subsub1\n"
-        "    - - 1\n"
-        "      - 2\n"
-        "      - val: 3\n"
-        "        spelled: three\n"
-        "      - 4\n"
-        "    - - subsub3\n"
-        "  - item4\n";
+        "- item1\n"
+        "- item2\n"
+        "- - sub1\n"
+        "  - sub2\n"
+        "- item3\n"
+        "- - - subsub1\n"
+        "  - - 1\n"
+        "    - 2\n"
+        "    - val: 3\n"
+        "      spelled: three\n"
+        "    - 4\n"
+        "  - - subsub3\n"
+        "- item4\n";
 
     char *got = cYAML_Print(root);
     if (!got) {

--- a/src/ethernet.c
+++ b/src/ethernet.c
@@ -6,9 +6,7 @@
 #include "tools.h"
 
 cJSON *detect_ethernet() {
-    cJSON *fake_root = cJSON_CreateObject();
     cJSON *j_inner = cJSON_CreateObject();
-    cJSON_AddItemToObject(fake_root, "ethernet", j_inner);
 
     char mac[20];
     if (get_mac_address(mac, sizeof mac)) {
@@ -18,5 +16,5 @@ cJSON *detect_ethernet() {
     if (hal_detect_ethernet)
         hal_detect_ethernet(j_inner);
 
-    return fake_root;
+    return j_inner;
 }

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -112,9 +112,7 @@ static void get_libc(cJSON *j_inner) {
 }
 
 cJSON *detect_firmare() {
-    cJSON *fake_root = cJSON_CreateObject();
     cJSON *j_inner = cJSON_CreateObject();
-    cJSON_AddItemToObject(fake_root, "firmware", j_inner);
 
     const char *uver = uboot_env_get_param("ver");
     if (uver) {
@@ -130,5 +128,5 @@ cJSON *detect_firmare() {
         hal_firmware_props(j_inner);
     get_god_app(j_inner);
 
-    return fake_root;
+    return j_inner;
 }

--- a/src/hal/hisi/ispreg.c
+++ b/src/hal/hisi/ispreg.c
@@ -370,7 +370,7 @@ static void ev300_enum_lanes(cJSON *j_inner, size_t lanes) {
 static void lvds_code_set(cJSON *j_inner, const char *param,
                           lvds_bit_endian_t val) {
     if (val == LVDS_ENDIAN_LITTLE)
-        ADD_PARAM(param, "LVDS_ENDIAN_LITTLE")
+        ADD_PARAM(param, "LVDS_ENDIAN_LITTLE");
     else
         ADD_PARAM(param, "LVDS_ENDIAN_BIG");
 }
@@ -522,7 +522,7 @@ static void hisi_cv300_sensor_data(cJSON *j_root) {
                 ADD_PARAM("raw-data-type", raw);
         }
         if (lvds0_ctrl.lvds_sync_mode == LVDS_SYNC_MODE_SOF)
-            ADD_PARAM("sync-mode", "LVDS_SYNC_MODE_SOF")
+            ADD_PARAM("sync-mode", "LVDS_SYNC_MODE_SOF");
         else
             ADD_PARAM("sync-mode", "LVDS_SYNC_MODE_SAV");
 

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -172,6 +172,8 @@ bailout:
 }
 
 typedef struct {
+    cJSON *json;
+    cJSON *j_part;
     const char *mtd_type;
     ssize_t totalsz;
     mpoint_t mpoints[MAX_MPOINTS];
@@ -180,34 +182,37 @@ typedef struct {
 static bool cb_mtd_info(int i, const char *name, struct mtd_info_user *mtd,
                         void *ctx) {
     enum_mtd_ctx *c = (enum_mtd_ctx *)ctx;
+    cJSON *j_inner = c->json;
 
     if (!c->mtd_type) {
         if (mtd->type == MTD_NORFLASH)
             c->mtd_type = "nor";
         else if (mtd->type == MTD_NANDFLASH)
             c->mtd_type = "nand";
-        yaml_printf("rom:\n"
-                    "  - type: %s\n"
-                    "    block: %dK\n",
-                    c->mtd_type, mtd->erasesize / 1024);
+        ADD_PARAM("type", c->mtd_type);
+        ADD_PARAM_FMT("block", "%dK", mtd->erasesize / 1024);
         if (strlen(nor_chip)) {
-            yaml_printf("    chip:\n%s", nor_chip);
+            ADD_PARAM("chip", nor_chip);
         }
-        yaml_printf("    partitions:\n");
+        cJSON_AddItemToObject(j_inner, "partitions", c->j_part);
     }
-    yaml_printf("      - name: %s\n"
-                "        size: 0x%x\n",
-                name, mtd->size);
+
+    j_inner = cJSON_CreateObject();
+    cJSON_AddItemToArray(c->j_part, j_inner);
+
+    ADD_PARAM("name", name);
+    ADD_PARAM_FMT("size", "0x%x", mtd->size);
+
     if (i < MAX_MPOINTS && *c->mpoints[i].path) {
-        yaml_printf("        path: %s\n", c->mpoints[i].path);
+        ADD_PARAM("path", c->mpoints[i].path);
     }
     if (!c->mpoints[i].rw) {
         char contains[1024] = {0};
         uint32_t sha1 = 0;
         if (examine_part(i, mtd->size, mtd->erasesize, &sha1, contains)) {
-            yaml_printf("        sha1: %.8x\n", sha1);
+            ADD_PARAM_FMT("sha1", "%.8x", sha1);
             if (*contains) {
-                yaml_printf("        contains:\n%s", contains);
+                ADD_PARAM("contains", contains);
             }
         }
     }
@@ -282,20 +287,34 @@ void enum_mtd_info(void *ctx, cb_mtd cb) {
     }
 }
 
-void print_mtd_info() {
+cJSON *get_mtd_info() {
     enum_mtd_ctx ctx;
     memset(&ctx, 0, sizeof(ctx));
+    ctx.json = cJSON_CreateObject();
+    ctx.j_part = cJSON_CreateArray();
+
     parse_partitions(ctx.mpoints);
+
     enum_mtd_info(&ctx, cb_mtd_info);
+    if (!ctx.mtd_type) {
+        // cb_mtd_info was never called.
+        cJSON_Delete(ctx.j_part);
+    }
+
+    cJSON *j_inner = ctx.json;
 
     if (ctx.totalsz)
-        yaml_printf("    size: %dM\n", ctx.totalsz / 1024 / 1024);
+        ADD_PARAM_FMT("size", "%dM", ctx.totalsz / 1024 / 1024);
 
     if (hal_fmc_mode) {
         const char *fmc_mode = hal_fmc_mode();
         if (fmc_mode)
-            printf("    addr-mode: %s\n", fmc_mode);
+            ADD_PARAM("addr-mode", fmc_mode);
     }
+
+    cJSON *json = cJSON_CreateArray();
+    cJSON_AddItemToArray(json, ctx.json);
+    return json;
 }
 
 static bool xm_warning;

--- a/src/mtd.h
+++ b/src/mtd.h
@@ -2,11 +2,12 @@
 #define MTD_H
 
 #include <mtd/mtd-abi.h>
+#include "cjson/cJSON.h"
 
 typedef bool (*cb_mtd)(int i, const char *name, struct mtd_info_user *mtd,
                        void *ctx);
 
-void print_mtd_info();
+cJSON *get_mtd_info();
 char *open_mtdblock(int i, int *fd, uint32_t size, int flags);
 void enum_mtd_info(void *ctx, cb_mtd cb);
 bool mtd_write(int mtd, uint32_t offset, uint32_t erasesize, const char *data,

--- a/src/ram.c
+++ b/src/ram.c
@@ -7,9 +7,7 @@
 #include "tools.h"
 
 cJSON *detect_ram() {
-    cJSON *fake_root = cJSON_CreateObject();
     cJSON *j_inner = cJSON_CreateObject();
-    cJSON_AddItemToObject(fake_root, "ram", j_inner);
 
     unsigned long media_mem = 0;
     uint32_t total_mem = hal_totalmem(&media_mem);
@@ -18,5 +16,5 @@ cJSON *detect_ram() {
     if (media_mem)
         ADD_PARAM_FMT("media", "%luM", media_mem / 1024);
 
-    return fake_root;
+    return j_inner;
 }

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -147,7 +147,7 @@ static void sony_imx291_params(sensor_ctx_t *ctx, int fd,
 
     int frsel = (READ(9) & 3);
     int hmax = READ(0x1d) << 8 | READ(0x1c);
-    ADD_PARAM_NUM("fps", sony_imx291_fps(frsel, hmax))
+    ADD_PARAM_NUM("fps", sony_imx291_fps(frsel, hmax));
     ctx->j_params = j_inner;
 }
 #endif
@@ -920,14 +920,13 @@ cJSON *detect_sensors() {
     sensor_ctx_t ctx;
     memset(&ctx, 0, sizeof(ctx));
 
-    cJSON *fake_root = cJSON_CreateObject();
-    cJSON *j_sensors = cJSON_AddArrayToObject(fake_root, "sensors");
+    cJSON *j_sensors = cJSON_CreateArray();
     ctx.j_sensor = cJSON_CreateObject();
     cJSON *j_inner = ctx.j_sensor;
     cJSON_AddItemToArray(j_sensors, j_inner);
 
     if (!getsensorid(&ctx)) {
-        cJSON_Delete(fake_root);
+        cJSON_Delete(j_sensors);
         return NULL;
     }
 
@@ -946,7 +945,7 @@ cJSON *detect_sensors() {
         hisi_vi_information(&ctx);
     }
 
-    return fake_root;
+    return j_sensors;
 }
 
 #endif

--- a/src/tools.h
+++ b/src/tools.h
@@ -11,30 +11,29 @@
 #define ARRCNT(a) (sizeof(a) / sizeof((a)[0]))
 
 #define ADD_PARAM(param, val)                                                  \
-    {                                                                          \
+    do {                                                                       \
         cJSON *strval = cJSON_CreateString(val);                               \
         cJSON_AddItemToObject(j_inner, param, strval);                         \
-    }
+    } while (0)
 
 #define ADD_PARAM_NOTNULL(param, val)                                          \
-    {                                                                          \
-        if (val != NULL) {                                                     \
+    do {                                                                       \
+        if (val != NULL)                                                       \
             ADD_PARAM(param, val);                                             \
-        }                                                                      \
-    }
+    } while (0)
 
 #define ADD_PARAM_NUM(param, num)                                              \
-    {                                                                          \
+    do {                                                                       \
         cJSON *numval = cJSON_CreateNumber(num);                               \
         cJSON_AddItemToObject(j_inner, param, numval);                         \
-    }
+    } while (0)
 
 #define ADD_PARAM_FMT(param, fmt, ...)                                         \
-    {                                                                          \
+    do {                                                                       \
         char val[1024];                                                        \
         snprintf(val, sizeof(val), fmt, __VA_ARGS__);                          \
         ADD_PARAM(param, val);                                                 \
-    }
+    } while (0)
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
 #define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
 


### PR DESCRIPTION
 * stops making autodumps when run without arguments.
 * adds a separate `upload` command, to make it clear the data is leaving the local network
 * moves the backup / upload work to the main process: no more background processes
 * refactors the MTD code to work with cJSON objects instead of printing to stdout

One side-effect of this change is that STDOUT isn't flushed anymore before trying to detect the sensors: all output happens after all the data has been collected.

Another change is that the output skips the initial "---" marker, making it a "bare document" in YAML terms.  Since we're only producing a single document, this shouldn't make any difference.