### PR TITLE
cYAML: Fix handling of empty objects.

### DIFF
--- a/src/cjson/cYAML_test.c
+++ b/src/cjson/cYAML_test.c
@@ -118,5 +118,20 @@ int main(int argc, char *argv[]) {
              "  - - subsub3\n"
              "- item4\n"
              );
+
+    run_test("empty objects",
+
+             "{ "
+             "  \"object\": {},"
+             "  \"array\": [],"
+             "  \"string\" : \"\""
+             "}",
+
+             "---\n"
+             "object: {}\n"
+             "array: []\n"
+             "string: \"\"\n"
+             );
+
     return 0;
 }


### PR DESCRIPTION
While working on the YAML code, I noticed it didn't handle empty strings, empty objects and empty arrays correctly: in that case, it would output invalid YAML (this limitation was present also before my re-write).  This fixes it.