### PR TITLE
Sigmastar: get soc from uboot environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,10 +67,12 @@ set(COMMON_LIB_SRC
     src/hwinfo.c
     src/hwinfo.h
     src/mmap.h
+    src/mtd.c
     src/sensors.c
     src/sensors.h
     src/tools.c
     src/tools.h
+    src/uboot.c
     src/version.h)
 
 set(IPCTOOL_SRC

--- a/src/hal/sstar.c
+++ b/src/hal/sstar.c
@@ -8,6 +8,7 @@
 #include "hal/common.h"
 #include "hal/sstar.h"
 #include "tools.h"
+#include "uboot.h"
 
 static unsigned char onsemi_addrs[] = {0x20, 0};
 static unsigned char sony_addrs[] = {0x34, 0};
@@ -51,8 +52,9 @@ bool sstar_detect_cpu(char *chip_name) {
     if (mem_reg(SSTAR_ADDR, &val, OP_READ)) {
         chip_generation = val;
 
-        char *soc_env = getenv("SOC");
-        if (soc_env && *soc_env) {
+        cmd_getenv_initial();
+        const char *soc_env = uboot_env_get_param("soc");
+        if (soc_env) {
             strcpy(chip_name, soc_env);
             return true;
         }

--- a/src/hal/sstar.h
+++ b/src/hal/sstar.h
@@ -23,5 +23,6 @@
 bool mstar_detect_cpu(char *chip_name);
 bool sstar_detect_cpu(char *chip_name);
 void sstar_setup_hal();
+void cmd_getenv_initial();
 
 #endif /* HAL_SSTAR_H */

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -292,6 +292,7 @@ void enum_mtd_info(void *ctx, cb_mtd cb) {
     }
 }
 
+#ifndef STANDALONE_LIBRARY
 cJSON *get_mtd_info() {
     enum_mtd_ctx ctx;
     memset(&ctx, 0, sizeof(ctx));
@@ -472,3 +473,4 @@ int mtd_unlock_cmd() {
 
     return EXIT_SUCCESS;
 }
+#endif


### PR DESCRIPTION
This was my initial idea to read the soc variable from the uboot environment. The additional source files doesn't increase the final binary size, so it might be viable, although I'm not perfectly happy with the current implementation.