### PR TITLE
Revert "Sigmastar: get soc from uboot environment"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,12 +67,10 @@ set(COMMON_LIB_SRC
     src/hwinfo.c
     src/hwinfo.h
     src/mmap.h
-    src/mtd.c
     src/sensors.c
     src/sensors.h
     src/tools.c
     src/tools.h
-    src/uboot.c
     src/version.h)
 
 set(IPCTOOL_SRC

--- a/src/hal/sstar.c
+++ b/src/hal/sstar.c
@@ -8,7 +8,6 @@
 #include "hal/common.h"
 #include "hal/sstar.h"
 #include "tools.h"
-#include "uboot.h"
 
 static unsigned char onsemi_addrs[] = {0x20, 0};
 static unsigned char sony_addrs[] = {0x34, 0};
@@ -51,13 +50,6 @@ bool sstar_detect_cpu(char *chip_name) {
 
     if (mem_reg(SSTAR_ADDR, &val, OP_READ)) {
         chip_generation = val;
-
-        cmd_getenv_initial();
-        const char *soc_env = uboot_env_get_param("soc");
-        if (soc_env) {
-            strcpy(chip_name, soc_env);
-            return true;
-        }
 
         switch (val) {
         case INFINITY5:

--- a/src/hal/sstar.h
+++ b/src/hal/sstar.h
@@ -23,6 +23,5 @@
 bool mstar_detect_cpu(char *chip_name);
 bool sstar_detect_cpu(char *chip_name);
 void sstar_setup_hal();
-void cmd_getenv_initial();
 
 #endif /* HAL_SSTAR_H */

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -292,7 +292,6 @@ void enum_mtd_info(void *ctx, cb_mtd cb) {
     }
 }
 
-#ifndef STANDALONE_LIBRARY
 cJSON *get_mtd_info() {
     enum_mtd_ctx ctx;
     memset(&ctx, 0, sizeof(ctx));
@@ -473,4 +472,3 @@ int mtd_unlock_cmd() {
 
     return EXIT_SUCCESS;
 }
-#endif

--- a/src/uboot.c
+++ b/src/uboot.c
@@ -181,13 +181,11 @@ static void uboot_setenv_cb(int mtd, uint32_t offset, const char *env,
     towrite = newenv;
 
 rewrite:
-#ifndef STANDALONE_LIBRARY
     if (fop == FOP_INTERACTIVE || fop == FOP_ROM) {
         crc32(towrite + CRC_SZ, env_len - CRC_SZ, &res_crc);
         *(uint32_t *)towrite = res_crc;
         mtd_write(mtd, offset, erasesize, towrite, env_len);
     }
-#endif
     if (uenv != towrite)
         memcpy(uenv, towrite, env_len);
 
@@ -199,7 +197,6 @@ bailout:
 enum {
     OP_PRINTENV = 0,
     OP_SETENV,
-    OP_GETENV,
 };
 
 typedef struct {
@@ -229,9 +226,6 @@ static bool cb_uboot_env(int i, const char *name, struct mtd_info_user *mtd,
                 uboot_setenv_cb(i, u_off, addr + u_off, c->key, c->value,
                                 mtd->erasesize, c->fop);
                 break;
-            case OP_GETENV:
-                uenv = addr + u_off;
-                break;
             }
             close(fd);
             return false;
@@ -253,13 +247,6 @@ int cmd_printenv() {
     };
     enum_mtd_info(&ctx, cb_uboot_env);
     return EXIT_SUCCESS;
-}
-
-void cmd_getenv_initial() {
-    ctx_uboot_t ctx = {
-        .op = OP_GETENV,
-    };
-    enum_mtd_info(&ctx, cb_uboot_env);
 }
 
 void set_env_param_ram(const char *key, const char *value) {


### PR DESCRIPTION
This is currently not supported on nand and also increases execution time due to the additional scanning for the uboot partition. I apologize for the back and forth on the commits.