### PR TITLE
tools: always check cmdline of streamer app

### DIFF
--- a/example/ipcinfo.c
+++ b/example/ipcinfo.c
@@ -147,15 +147,8 @@ static void print_streamer() {
     pid_t godpid;
 
     if ((godpid = get_god_pid(NULL, 0)) > 0) {
-        snprintf(sname, sizeof(sname), "/proc/%d/cmdline", godpid);
-        FILE *fp = fopen(sname, "r");
-        if (!fp)
-            exit(EXIT_FAILURE);
-        if (!fgets(sname, sizeof(sname), fp))
-            exit(EXIT_FAILURE);
-        puts(sname);
-
-        fclose(fp);
+        if (get_pid_cmdline(godpid, sname))
+            puts(sname);
     }
 }
 

--- a/src/firmware.c
+++ b/src/firmware.c
@@ -21,15 +21,8 @@ static void get_god_app(cJSON *j_inner) {
     pid_t godpid;
 
     if ((godpid = get_god_pid(NULL, 0)) > 0) {
-        snprintf(sname, sizeof(sname), "/proc/%d/cmdline", godpid);
-        FILE *fp = fopen(sname, "r");
-        if (!fp)
-            return;
-        if (!fgets(sname, sizeof(sname), fp))
-            return;
-        ADD_PARAM("main-app", sname);
-
-        fclose(fp);
+        if (get_pid_cmdline(godpid, sname))
+            ADD_PARAM("main-app", sname);
     }
 }
 

--- a/src/tools.h
+++ b/src/tools.h
@@ -55,6 +55,7 @@ void restore_printk();
 void disable_printk();
 uint32_t ceil_up(uint32_t n, uint32_t offset);
 pid_t get_god_pid(char *shortname, size_t shortsz);
+bool get_pid_cmdline(pid_t godpid, char *cmdname);
 
 // avoid warnings for old compilers
 #if __GNUC__ < 7


### PR DESCRIPTION
On some devices the kernel module process has the highest usage, this prevents the successful detection of the streamer app.
We can filter out kernel processes by checking the cmdline.