### PR TITLE
Fixes handling of the NOR chip details.

### DIFF
--- a/src/boards/xm.c
+++ b/src/boards/xm.c
@@ -44,13 +44,13 @@ static void detect_nor_chip() {
     // XMMTD_GETFLASHNAME
     memset(buf, 0, sizeof buf);
     if (ioctl(fd, 0x40044DAAu, &buf) >= 0) {
-        sprintf(nor_chip, "      name: \"%s\"\n", buf);
+        sprintf(nor_chip_name, "%s", buf);
     }
 
     // XMMTD_GETFLASHID
     uint32_t flash_id;
     if (ioctl(fd, 0x40044DA9u, &flash_id) >= 0) {
-        sprintf(nor_chip + strlen(nor_chip), "      id: 0x%06x\n", flash_id);
+        sprintf(nor_chip_id, "0x%06x", flash_id);
     }
 
     close(fd);

--- a/src/chipid.c
+++ b/src/chipid.c
@@ -16,7 +16,8 @@
 
 int chip_generation;
 char chip_name[128];
-char nor_chip[128];
+char nor_chip_name[128];
+char nor_chip_id[128];
 static char chip_manufacturer[128];
 
 static long get_uart0_address() {

--- a/src/chipid.h
+++ b/src/chipid.h
@@ -17,7 +17,8 @@ extern int chip_generation;
 extern char chip_name[128];
 extern char control[128];
 extern char sensor_id[128];
-extern char nor_chip[128];
+extern char nor_chip_name[128];
+extern char nor_chip_id[128];
 
 const char *getchipname();
 

--- a/src/mtd.c
+++ b/src/mtd.c
@@ -196,8 +196,15 @@ static bool cb_mtd_info(int i, const char *name, struct mtd_info_user *mtd,
             c->mtd_type = "nand";
         ADD_PARAM("type", c->mtd_type);
         ADD_PARAM_FMT("block", "%dK", mtd->erasesize / 1024);
-        if (strlen(nor_chip)) {
-            ADD_PARAM("chip", nor_chip);
+        if (strlen(nor_chip_name) || strlen(nor_chip_id)) {
+            cJSON *j_inner = cJSON_CreateObject();
+            if (strlen(nor_chip_name)) {
+                ADD_PARAM("name", nor_chip_name);
+            }
+            if (strlen(nor_chip_id)) {
+                ADD_PARAM("id", nor_chip_id);
+            }
+            cJSON_AddItemToObject(c->json, "chip", j_inner);
         }
         cJSON_AddItemToObject(j_inner, "partitions", c->j_part);
     }


### PR DESCRIPTION
In my initial refactoring of `cb_mtd_info()`, I didn't realize that `nor_chip` contains a preformatted chunk of YAML (I had assumed a string).