### PR TITLE
Fix ipcinfo GC2093 detection

### DIFF
--- a/src/sensors.c
+++ b/src/sensors.c
@@ -768,6 +768,7 @@ static int detect_galaxycore_sensor(sensor_ctx_t *ctx, int fd,
     switch (res) {
     case 0x2053:
     case 0x2083:
+    case 0x2093:
     case 0x4023:
     case 0x4653:
         sprintf(ctx->sensor_id, "GC%04x", res);
@@ -796,7 +797,6 @@ static int detect_galaxycore_sensor(sensor_ctx_t *ctx, int fd,
     case 0x2053:
     case 0x2063:
     case 0x2083:
-    case 0x2093:
     case 0x3003:
     case 0x4023:
     case 0x4653:


### PR DESCRIPTION
Hi, the GC2093 sensor's chip id is at 0x3f0 and 0x3f1:  

(source: [GC2093_CSP_Datasheet_V1.1_20201012.pdf](https://github.com/libc0607/gc2093_modes/blob/main/hardware/GC2093_CSP_Datasheet_V1.1_20201012.pdf))  

![image](https://github.com/user-attachments/assets/5903de08-76ec-4372-bdec-8d66a9dd8d17)  

I've tested that and it's ok with my sensor board now 

![image](https://github.com/user-attachments/assets/f3220924-30bd-427e-9227-1451dbe421da)  
