### PR TITLE
Hoist MIPI/VI struct dumps to file-scope C declarations

### DIFF
--- a/docs/sensor-driver-extraction.md
+++ b/docs/sensor-driver-extraction.md
@@ -361,6 +361,15 @@ The output is a scaffold, not a finished driver:
   trace values as `/* TODO: derive */` placeholders. The math driving
   those values is **not** in the trace — see "Live-reading the AE
   state" below for how to capture value distributions.
+- File-scope MIPI/VI struct declarations (e.g.,
+  `combo_dev_attr_t SENSOR_ATTR = { … }`,
+  `pstViDevAttr VI_DEV_ATTR_S = { … }`) are emitted between the SDK
+  stubs and the init function, wrapped in `#if 0 / #endif`. Standalone
+  builds skip them (the references to vendor enums like
+  `INPUT_MODE_MIPI` aren't visible without `hi_mipi.h`); when
+  integrating into a HiSilicon SDK build, remove the `#if 0/#endif`
+  to drop the struct definitions in alongside the rest of the
+  scaffold.
 
 ### `trace_diff.py`
 

--- a/tools/test_pipeline.sh
+++ b/tools/test_pipeline.sh
@@ -13,11 +13,16 @@ cd "$(dirname "$0")/.."
 tmp=$(mktemp -d)
 trap "rm -rf $tmp" EXIT
 
-# Minimal synthetic trace: probe + init (reset + a few writes + stream-on)
-# + runtime (one register written enough times to trigger the runtime
-# heuristic at threshold >= 3).
+# Minimal synthetic trace: a MIPI struct dump (pre_sensor) + init (reset
+# + a few writes + stream-on) + runtime (one register written enough
+# times to trigger the runtime heuristic at threshold >= 3).
 cat > "$tmp/sample.log" <<'TRACE'
 [100] child 101 created
+combo_dev_attr_t SENSOR_ATTR = {
+	.devno = 0,
+	.input_mode = INPUT_MODE_MIPI,
+	.lane_id = {0, 2, -1, -1},
+};
 sensor_i2c_change_addr(0x60);
 sensor_write_register(0x100, 0x0);
 usleep(10000)
@@ -54,6 +59,10 @@ grep -q '^void testsensor_linear_init' "$tmp/driver.c" \
     || { echo "linear_init function not emitted"; exit 1; }
 grep -q '^void testsensor_ae_step' "$tmp/driver.c" \
     || { echo "ae_step skeleton not emitted"; exit 1; }
+grep -q '^combo_dev_attr_t SENSOR_ATTR' "$tmp/driver.c" \
+    || { echo "MIPI struct not emitted at file scope"; exit 1; }
+grep -q '^#if 0' "$tmp/driver.c" \
+    || { echo "struct block not wrapped in #if 0"; exit 1; }
 
 echo "== gcc -fsyntax-only =="
 gcc -Wall -Wextra -fsyntax-only "$tmp/driver.c"

--- a/tools/trace_segment.py
+++ b/tools/trace_segment.py
@@ -31,7 +31,11 @@ RE_READ_ERR = re.compile(r"^sensor_read_register\(0x([0-9a-fA-F]+)\);\s*/\*\s*\[
 RE_ADDR = re.compile(r"^sensor_i2c_change_addr\(0x([0-9a-fA-F]+)\);?")
 RE_USLEEP = re.compile(r"^usleep\((\d+)\)")
 RE_BANNER = re.compile(r"^=+\s*([a-zA-Z0-9_\-]+)\s*=+")
-RE_STRUCT_OPEN = re.compile(r"^[\w]+\s*=\s*\{$|^\.\w+\s*=\s*\{$")
+# Top-level C struct declaration opener: `type name = {` at column 0,
+# nothing after the `{`. Doesn't try to track nested `.field = {` blocks
+# - those are just text until the matching top-level `};` closes the
+# whole declaration.
+RE_STRUCT_OPEN = re.compile(r"^\w+\s+\w+\s*=\s*\{$")
 
 # Lines we drop on sight (noise, not register ops)
 RE_NOISE = re.compile(

--- a/tools/trace_to_driver.py
+++ b/tools/trace_to_driver.py
@@ -9,6 +9,7 @@ Usage:
 """
 import argparse
 import json
+import re
 import sys
 
 
@@ -74,10 +75,9 @@ def emit_phase(events, indent="  "):
         elif ev["kind"] == "banner":
             out.append(f"{indent}/* === bus: {ev['dev']} === */\n")
         elif ev["kind"] == "struct":
-            out.append(f"{indent}/*\n")
-            for line in ev["text"].splitlines():
-                out.append(f"{indent} * {line}\n")
-            out.append(f"{indent} */\n")
+            # Structs are hoisted to file scope by emit_structs_block; skip
+            # them here so they don't appear inline as comments.
+            pass
         elif ev["kind"] in ("read", "read_err"):
             # Reads happen during probe and chip-id checks. Document but
             # do not emit as code (they don't belong in init).
@@ -90,6 +90,61 @@ def emit_phase(events, indent="  "):
             line += " */\n"
             out.append(line)
     return "".join(out)
+
+
+# Parses `combo_dev_attr_t SENSOR_ATTR = {` -> ("combo_dev_attr_t", "SENSOR_ATTR")
+RE_STRUCT_HEAD = re.compile(r"^(\w+)\s+(\w+)\s*=\s*\{$")
+
+
+def collect_structs(phases):
+    """Return list of (type_name, var_name, text) tuples, deduped by var_name.
+
+    A streamer that issues multiple HI_MPI_*_SetDevAttr calls during init
+    (e.g., per-pipe configuration) shows up as several struct events with
+    the same var_name; the last value wins, mirroring the final state the
+    sensor was configured into.
+    """
+    by_name = {}
+    for events in phases.values():
+        for ev in events:
+            if ev["kind"] != "struct":
+                continue
+            head = ev["text"].splitlines()[0]
+            m = RE_STRUCT_HEAD.match(head)
+            if not m:
+                continue
+            type_name, var_name = m.group(1), m.group(2)
+            by_name[var_name] = (type_name, var_name, ev["text"])
+    return list(by_name.values())
+
+
+def emit_structs_block(structs):
+    """Emit MIPI/VI struct declarations wrapped in `#if 0` so the standalone
+    build skips them (they reference vendor-only enum constants like
+    INPUT_MODE_MIPI). User removes the guard when integrating into a
+    HiSilicon SDK build, where the enums and types are in scope via
+    hi_comm_video.h / hi_mipi.h.
+    """
+    if not structs:
+        return ""
+    lines = []
+    lines.append("/*")
+    lines.append(" * MIPI/VI device attributes captured from the running streamer's")
+    lines.append(" * HI_MPI_*_SetDevAttr ioctls. Wrapped in #if 0 so the standalone")
+    lines.append(" * scaffold builds without vendor headers; remove the #if 0/#endif")
+    lines.append(" * when integrating into a HiSilicon SDK build (the enum constants")
+    lines.append(" * and struct typedefs come from hi_comm_video.h / hi_mipi.h).")
+    lines.append(" *")
+    lines.append(" * Note: ipctool's V4 VI-dev dumper emits the variable name in")
+    lines.append(" * `pstViDevAttr VI_DEV_ATTR_S` order; in real SDK code the type")
+    lines.append(" * is VI_DEV_ATTR_S and the variable name is yours to choose.")
+    lines.append(" */")
+    lines.append("#if 0")
+    for _, _, text in structs:
+        lines.append(text)
+        lines.append("")  # blank between declarations
+    lines.append("#endif")
+    return "\n".join(lines) + "\n"
 
 
 def runtime_summary(events):
@@ -171,6 +226,11 @@ def main():
     phases = data["phases"]
 
     parts = [HEADER.format(src=args.segments, sensor=args.sensor)]
+
+    structs = collect_structs(phases)
+    if structs:
+        parts.append("\n")
+        parts.append(emit_structs_block(structs))
 
     init = phases.get("init", [])
     post_init = phases.get("post_init", [])


### PR DESCRIPTION
Closes the third \"real gap\" from #145's plan-vs-shipped audit. Follow-up to #145 / #146 / #147.

## Summary

MIPI and VI device-attribute structures captured by `ipctool trace` are now emitted as proper C struct initializers at file scope in the generated scaffold, wrapped in `#if 0 / #endif` so standalone builds skip them. Removing the guard during SDK integration drops them in alongside the rest of the scaffold.

## Why

`ipctool trace` already pretty-prints HiSilicon's `combo_dev_attr_t` and `VI_DEV_ATTR_S` ioctl payloads as valid C struct initializers (decoder lives in `src/hal/hisi/ptrace.c`). Until this PR, `trace_to_driver.py` was just embedding the captured text as multi-line `/* */` comments inside the init function — visible to the user but not usable as C.

That left MIPI/VI bring-up as a manual transcription step. With #145 the user got a perfect register init table; they then had to re-type ~20 fields of struct setup by hand from the trace's comment block.

## What it now produces

Excerpt from a regenerated SC2315E + Majestic scaffold:

```c
/* --- end SDK stubs --- */

/*
 * MIPI/VI device attributes captured from the running streamer's
 * HI_MPI_*_SetDevAttr ioctls. Wrapped in #if 0 so the standalone
 * scaffold builds without vendor headers; remove the #if 0/#endif
 * when integrating into a HiSilicon SDK build (the enum constants
 * and struct typedefs come from hi_comm_video.h / hi_mipi.h).
 *
 * Note: ipctool's V4 VI-dev dumper emits the variable name in
 * `pstViDevAttr VI_DEV_ATTR_S` order; in real SDK code the type
 * is VI_DEV_ATTR_S and the variable name is yours to choose.
 */
#if 0
combo_dev_attr_t SENSOR_ATTR = {
    .devno = 0,
    .input_mode = INPUT_MODE_MIPI,
    .data_rate = MIPI_DATA_RATE_X1,
    .img_rect = {0, 0, 1920, 1080},
    .mipi_attr = {
        .input_data_type = DATA_TYPE_RAW_10BIT,
        .wdr_mode = HI_MIPI_WDR_MODE_NONE,
        .lane_id = {0, 2, -1, -1},
    },
};

pstViDevAttr VI_DEV_ATTR_S = {
    .enIntfMode = 6,
    ...
};

#endif

void sc2315e_linear_init(VI_PIPE ViPipe) {
    ...
```

## Two changes

**`trace_segment.py`**: the existing `RE_STRUCT_OPEN` only matched single-identifier openers (`name = {`), so the actual two-word ipctool dumps (`type name = {`) fell through to plain text and the orphan `};` at the end leaked into whatever phase came next. Tightened the regex to require `\\w+\\s+\\w+\\s*=\\s*\\{$`. Side effect: init phase event count goes 172 → 173 on the regression capture (the leaked `};` no longer counts), but the diff against `widgetii/smart_sc2315e` is unchanged at 100/100/100% — confirms it was always noise.

**`trace_to_driver.py`**: new `collect_structs(phases)` walks all phases and dedupes by variable name (last-seen value wins, mirroring multi-pipe configs where a streamer issues several `SetDevAttr` calls). `emit_structs_block(structs)` writes them at file scope between the SDK stubs and the init function, wrapped in `#if 0 / #endif`. `emit_phase` no longer emits structs as inline comments (they're hoisted).

## Why `#if 0`?

The struct bodies reference vendor-only enum constants (`INPUT_MODE_MIPI`, `DATA_TYPE_RAW_10BIT`, `HI_MIPI_WDR_MODE_NONE`, `MIPI_DATA_RATE_X1`). Without `hi_mipi.h` and friends, the standalone scaffold can't compile them. The two clean options were:

1. Stub the enums to `int` constants — uglier, error-prone, and the user has to undo it during integration anyway.
2. `#if 0` — one-line edit at integration time, zero stubs, the C is identical to what'd be in the vendor SDK.

(2) wins. The standalone build (which #146 introduced and CI tests) keeps passing `gcc -Wall -Wextra -fsyntax-only` because the preprocessor strips the block.

## Cosmetic note for follow-up

`src/hal/hisi/ptrace.c:771` emits `pstViDevAttr VI_DEV_ATTR_S = {` — `pstViDevAttr` was meant to be the variable name but is in the type slot, reversed from SDK convention (`VI_DEV_ATTR_S` is the type). Not fixed in this PR — changing the dump format would break existing trace parsers and is unrelated to the extraction pipeline. The comment block calls this out so the user renames when integrating.

## Test plan

- [x] `tools/test_pipeline.sh` extended with a synthetic struct event; asserts file-scope declaration and `#if 0` wrapper. Passes.
- [x] `gcc -Wall -Wextra -fsyntax-only` and `gcc -c` on the regenerated SC2315E + Majestic scaffold both succeed
- [x] `trace_diff.py` against `widgetii/smart_sc2315e/sc2315e_sensor_ctl.c::sc2315e_linear_1080P30_init` reports 100/100/100% (unchanged from pre-PR)
- [x] CI `test-extraction-pipeline` job picks up the new struct assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)