### PR TITLE
Cross-diff trace against widgetii/sc_sc2315e (older RE port)

### DIFF
--- a/docs/sensor-driver-extraction.md
+++ b/docs/sensor-driver-extraction.md
@@ -516,6 +516,46 @@ function carries the default. This is **expected**, not a bug; scope
 the diff to the `linear_init` function on both sides and the mismatches
 disappear.
 
+### Triangulating against multiple references
+
+When a sensor has more than one published source — e.g. an OpenIPC port
+**and** an older reverse-engineering effort — diffing against both lets
+you triangulate registers that appear in only one as either:
+
+- **In trace + only in ref-A**: ref-B is incomplete (the RE missed
+  this register, or the port pruned it).
+- **In trace + only in ref-B**: ref-A drifted from the binary
+  (vendor patched the closed driver, port didn't follow).
+- **In both refs but not in trace**: probably dead code in both refs,
+  or behind a build flag the trace didn't exercise.
+- **In trace and both refs**: high confidence, ship it.
+
+For SC2315E specifically, the four artifacts available — the trace
+from Majestic, the trace from Sofia, `widgetii/smart_sc2315e`
+(OpenIPC port from SC2231 SDK template), and `widgetii/sc_sc2315e`
+(older RE port from SC2235 SDK template) — agree byte-for-byte on
+init: 172 writes, 169 unique addresses, identical values, identical
+order, every pair-wise comparison at 100/100/100%.
+
+```bash
+# OpenIPC port
+python3 tools/trace_diff.py generated.c \
+    /tmp/smart_sc2315e/sc2315e_sensor_ctl.c \
+    --gen-scope sc2315e_linear_init \
+    --ref-scope sc2315e_linear_1080P30_init
+
+# Reverse-engineered port (note: int return, sensor_write_register_0)
+python3 tools/trace_diff.py generated.c \
+    /tmp/sc_sc2315e/sc2235_sensor_ctl.c \
+    --gen-scope sc2315e_linear_init \
+    --ref-scope sc2235_init
+```
+
+`trace_diff.py` accepts both `void <name>(...)` and `int <name>(...)`
+function definitions, and its register-write regex matches both
+`sensor_write_register(...)` and `sensor_write_register_0(...)`
+(the bus-numbered suffix used by the older RE port).
+
 Other expected sources of mismatch on a real capture:
 
 - **Registers in the reference source but not in the trace**: these are

--- a/tools/test_pipeline.sh
+++ b/tools/test_pipeline.sh
@@ -84,4 +84,31 @@ python3 tools/trace_diff.py "$tmp/driver.c" "$tmp/driver.c" \
 grep -q '100.0%)' "$tmp/diff.out" \
     || { echo "self-diff not 100%"; exit 1; }
 
+# Diff against a reference that uses the older RE-port shape:
+# `int <fn>(VI_PIPE)` returning int (not void), with
+# `sensor_write_register_0(...)` (bus-numbered suffix). Validates that
+# extract_function_body and RE_ANY_WRITE handle both styles.
+echo "== trace_diff.py cross-style ref =="
+cat > "$tmp/ref_old_style.c" <<'REF'
+#include <unistd.h>
+typedef int VI_PIPE;
+static void sensor_write_register_0(unsigned int a, unsigned int v)
+{ (void)a; (void)v; }
+
+int oldstyle_init(VI_PIPE pipe) {
+    (void)pipe;
+    sensor_write_register_0(0x100, 0x0);
+    sensor_write_register_0(0x3034, 0x81);
+    sensor_write_register_0(0x3039, 0xa6);
+    sensor_write_register_0(0x320e, 0x4);
+    sensor_write_register_0(0x100, 0x1);
+    return 0;
+}
+REF
+python3 tools/trace_diff.py "$tmp/driver.c" "$tmp/ref_old_style.c" \
+    --gen-scope testsensor_linear_init \
+    --ref-scope oldstyle_init | tee "$tmp/cross.out"
+grep -q 'address match:  4 / 4' "$tmp/cross.out" \
+    || { echo "cross-style ref didn't match (relaxed regex broken?)"; exit 1; }
+
 echo "OK: pipeline test passed"

--- a/tools/trace_diff.py
+++ b/tools/trace_diff.py
@@ -26,9 +26,11 @@ RE_WRITE = re.compile(
     r"((?:0[xX])?[0-9a-fA-F]+)\s*,\s*"
     r"((?:0[xX])?[0-9a-fA-F]+)\s*\)"
 )
-# Wider net for things like sc2315e_write_register(...).
+# Wider net for things like sc2315e_write_register(...) or
+# sensor_write_register_0(...) (the older RE port at widgetii/sc_sc2315e
+# uses the bus-numbered suffix).
 RE_ANY_WRITE = re.compile(
-    r"\b\w*write_register\s*\(\s*"
+    r"\b\w*write_register\w*\s*\(\s*"
     r"(?:[^,]+,\s*)?"
     r"((?:0[xX])?[0-9a-fA-F]+)\s*,\s*"
     r"((?:0[xX])?[0-9a-fA-F]+)\s*\)"
@@ -44,12 +46,18 @@ def parse_int(s):
 
 
 def extract_function_body(src, fn_name):
-    """Return text inside `void <fn_name>(...) { ... }`, brace-balanced.
+    """Return text inside `<rettype> <fn_name>(...) { ... }`, brace-balanced.
 
-    Strings/comments are not handled — fine for these driver files which
+    rettype is any whitespace-delimited token (int, void, HI_S32, HI_VOID,
+    static, etc.) - some references use C int returns instead of void.
+    Strings/comments are not handled - fine for these driver files which
     keep everything on one line per write.
     """
-    pat = re.compile(r"\bvoid\s+" + re.escape(fn_name) + r"\s*\([^)]*\)\s*\{")
+    # Match a function definition: identifier(s) before the name, then (args) {
+    # The qualifier+rettype block can include `static`, `inline`, multiple words.
+    pat = re.compile(
+        r"(?:\b\w+\s+)+" + re.escape(fn_name) + r"\s*\([^)]*\)\s*\{"
+    )
     m = pat.search(src)
     if not m:
         return None


### PR DESCRIPTION
Closes the sixth gap from #145's plan-vs-shipped audit. Triangulates the trace-extracted scaffold against the older reverse-engineered port at widgetii/sc_sc2315e in addition to widgetii/smart_sc2315e (already covered).

## Headline result

Four artifacts, all converging on the same canonical SC2315E init:

| pair | address | value | LCS |
|---|---|---|---|
| trace (Majestic) vs `smart_sc2315e` | 100% | 100% | 100% |
| trace (Majestic) vs `sc_sc2315e` | 100% | 100% | 100% |
| `smart_sc2315e` vs `sc_sc2315e` (refs only) | 100% | 100% | 100% |
| trace (Majestic) vs trace (Sofia) (from #145) | 100% | 100% | 100% |

172 writes, 169 unique addresses, identical values, identical order across every pair. No drift, no missing regs. The trace pipeline reliably extracts the canonical sequence, and the two independent reverse-engineering efforts converged on the exact same answer.

## What changed

Two small relaxations in `trace_diff.py` were needed to make the cross-diff actually run:

**1. `extract_function_body()`** — previously hard-required `void <fn>` to open. The RE port's init is `int sc2235_init(VI_PIPE)`, so the scope flag silently matched zero writes (the symptom in my first attempt). Relaxed to accept any whitespace-delimited rettype/qualifier sequence.

**2. `RE_ANY_WRITE`** — expected the register-write call name to end at `write_register(`. The RE port uses `sensor_write_register_0(...)` (bus-numbered suffix). Allowed an optional `\\w*` after `register` before the open paren.

Both are deliberately permissive: they accept the new shapes without losing precision on the old ones.

## Test plan

- [x] `tools/test_pipeline.sh` extended with a synthetic ref using the older RE-port shape (`int xxx_init`, `sensor_write_register_0(...)`); asserts 100% match. Catches regressions in the relaxed regexes.
- [x] Pair-wise diffs of all four artifacts above run clean
- [x] CI `test-extraction-pipeline` job picks up both old and new fixture assertions
- [x] No regression on existing self-diff (still 100%)

## Audit progress after this PR

| # | Status |
|---|---|
| 1 (compile-test scaffold) | merged in #146 |
| 2 (AE callback skeleton) | merged in #147 |
| 3 (MIPI/VI struct output) | merged in #148 |
| 4 (mode-switch capture) | merged in #149 |
| 5 (regression check) | done in #146 |
| 6 (sc_sc2315e cross-diff) | **this PR** |
| 7 (sofia-vs-majestic.md writeup) | open — could fold into the existing docs as a worked example |

🤖 Generated with [Claude Code](https://claude.com/claude-code)