### PR TITLE
sensor: fix IMX335 misdetected as IMX347 after WDR cycle (#157)

### DIFF
--- a/src/sensors.c
+++ b/src/sensors.c
@@ -158,12 +158,19 @@ static int detect_sony_sensor(sensor_ctx_t *ctx, int fd,
     if (i2c_change_addr(fd, i2c_addr) < 0)
         return false;
 
-    // HINT: 0x3057 also can be used for IMX335 (chip_id == 0x07)
-    // OR 0x3415 == 0x20 && 0x3418 == 0x27
+    // 0x3057 is Y_OUT_SIZE MSB (host-writable), not a chip ID — Sony
+    // sensors have no dedicated chip ID register. IMX335 can read 0x06
+    // here after a WDR-cropping cycle (#157). Disambiguate via OB
+    // cropping defaults that survive majestic init:
+    //   IMX335: 0x3072=0x28, 0x3074=0xB0
+    //   IMX347: 0x3072=0x14, 0x3074=0x3C
     int chip_id = READ(0x57);
     if (chip_id == 0x06) {
-        sprintf(ctx->sensor_id, "IMX347");
-        return true;
+        if (!(READ(0x72) == 0x28 && READ(0x74) == 0xB0)) {
+            sprintf(ctx->sensor_id, "IMX347");
+            return true;
+        }
+        // IMX335 with reprogrammed Y_OUT_SIZE — fall through to 0x316A.
     }
 
     if (READ(0x41C) == 0x47) {


### PR DESCRIPTION
## Summary

- Fixes #157. `0x3057` is `Y_OUT_SIZE[12:0]` MSB (host-writable per both datasheets), not a chip ID — Sony sensors have no dedicated chip ID register. WDR vertical cropping on IMX335 reprograms Y_OUT_SIZE so the MSB reads `0x06`, colliding with IMX347's reset default, and the unconditional `0x3057 == 0x06 → IMX347` short-circuit misdetects.
- Disambiguate via OB cropping registers with distinct datasheet defaults that survive majestic init: IMX335 reads `0x3072=0x28, 0x3074=0xB0`; IMX347 reads `0x3072=0x14, 0x3074=0x3C`. When the IMX335 fingerprint matches, fall through to the existing `0x316A` IMX335 path.
- Note on the originally proposed `(0x316A & 0xFC) == 0x7C` cross-check: IMX347 datasheet p.40 shows the same fixed bits as IMX335, so that check alone is not a discriminator — it's an INCKSEL4 shape, not a chip identifier.

## Test plan

- [x] Cross-compiled static-musl + UPX-packed (matches release pipeline shape; also avoids the #158 startup segfault on legacy kernels).
- [x] Verified on real IMX335 dev camera (HiSilicon GK7205V300, kernel 4.9.37, IMX335 4-lane MIPI) in the bug-triggering state — master HEAD reports `imx347_i2c`, this PR reports `imx335_i2c` from the same registers, same boot.
- [x] Sanity-checked across `killall majestic` (sensor retains register state without a power-cycle); behaviour is consistent.
- [ ] **IMX347 hands-on verification wanted** — no IMX347 sample on hand. The patch only diverges from current behaviour when both `0x3072 == 0x28 && 0x3074 == 0xB0` (IMX335 factory OB defaults); a real IMX347 reading those exact values would have to be deliberately programmed that way, and no published profile does, so false-positive risk is low — but a confirmation from anyone with the part would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)