### PR TITLE
clocks(v5): annotate HPM with source (chip|board) and svb_version

### DIFF
--- a/src/hal/hisi/clocks_v5.c
+++ b/src/hal/hisi/clocks_v5.c
@@ -238,6 +238,54 @@ static void v5_extra(cJSON *root, bool brief) {
         cJSON_AddItemToObject(root, "ssmod", ss);
     }
 
+    /* HPM annotations layered onto the standard hpm decoder output:
+     *   source       -- where HPM_STORAGE_REG bits[9:0] came from.
+     *                   bit[30] (u_hpm_storage_reg.use_board_hpm) tells us
+     *                   whether the value reflects an in-die measurement
+     *                   averaged by boot software ("chip") or a board
+     *                   fixture's calibration override ("board"). The
+     *                   "chip" value is the real silicon process bin;
+     *                   the "board" value is whatever the manufacturing
+     *                   line decided to ship.
+     *   svb_version  -- SVB_VER_REG bits[5:2] (u_svb_version_reg.svb_type),
+     *                   per svb.h's enum product_type. The binning
+     *                   threshold for "this die is fast enough" depends
+     *                   on the SVB version (CORE_HPM_BOUND_10 / _20 /
+     *                   _10_ESMT in svb.h). When this is "none" the
+     *                   firmware isn't running SVB at all and the bin
+     *                   classification is informational only. */
+    cJSON *hpm = cJSON_GetObjectItemCaseSensitive(root, "hpm");
+    if (hpm) {
+        uint32_t hpm_storage = 0;
+        uint32_t svb_ver = 0;
+        bool use_board_hpm = false;
+        if (mem_reg(V5_SYSCTRL_BASE + 0x340, &hpm_storage, OP_READ))
+            use_board_hpm = (hpm_storage >> 30) & 0x1;
+        const char *svb_name = "none";
+        if (mem_reg(V5_SYSCTRL_BASE + 0x168, &svb_ver, OP_READ)) {
+            switch ((svb_ver >> 2) & 0xF) {
+            case 1:
+                svb_name = "10";
+                break;
+            case 2:
+                svb_name = "20";
+                break;
+            case 3:
+                svb_name = "00";
+                break;
+            case 4:
+                svb_name = "608";
+                break;
+            default:
+                svb_name = "none";
+                break;
+            }
+        }
+        cJSON *j_inner = hpm;
+        ADD_PARAM("source", use_board_hpm ? "board" : "chip");
+        ADD_PARAM("svb_version", svb_name);
+    }
+
     /* Per-site HPM live readings -- only in full output. The canonical
      * core_hpm_value at HPM_STORAGE_REG is already surfaced by the
      * generic hpm decoder via v5_hpms[]. */


### PR DESCRIPTION
Follow-up to #168. Two cheap, useful annotations on the existing V5 `hpm` block — both surfaced from registers we already discovered while bringing up Hi3519DV500.

## What

| Field | Source | Meaning |
|------|--------|---------|
| `source` | `HPM_STORAGE_REG` bit[30] (`u_hpm_storage_reg.use_board_hpm`) | `chip` = in-die measurement averaged by boot software; `board` = board-fixture calibration override. |
| `svb_version` | `SVB_VER_REG` (SYSCTRL+0x168) bits[5:2] (`u_svb_version_reg.svb_type`) | `none` / `10` / `20` / `00` / `608` per `enum product_type` in svb.h. |

The `source` annotation matters when comparing HPM readings across boards — a `board` value is whatever the manufacturing line decided to ship, not the real silicon process bin.

`svb_version` is the missing piece for SVB-version-aware binning. svb.h ships three different boundary constants (`CORE_HPM_BOUND_10` = 230, `CORE_HPM_BOUND_20` = 222, `CORE_HPM_BOUND_10_ESMT` = 210) and the "right" threshold depends on which SVB the firmware is configured for. When `svb_version=none` (this board's case), the firmware isn't running SVB at all and the standard tri-state classification is informational only.

## Output on Hi3519DV500

```yaml
clocks:
  hpm:
    bin: high
    source: chip            # NEW
    svb_version: none       # NEW
```

`ipctool clocks` (full) appends `source` and `svb_version` after the existing `reg/raw/value/bin/binning_window/aux_reg/aux_value/aux_name` block.

## Test plan

- [x] Reads HPM_STORAGE_REG=`0x12d47d2c` → bit[30]=0 → `source: chip` ✓
- [x] Reads SVB_VER_REG=`0x00100200` → svb_type=0 → `svb_version: none` ✓
- [x] CI green on all three matrix targets (arm32 / mips32 / arm64)
- [ ] Verify on a board where SVB is actually configured (svb_type ∈ {1,2,3,4}) — none in the lab right now

## Not in scope

- **SVB-aware bin thresholding** — i.e., picking `bin_min` from the live SVB version rather than the V4-style window 210..310 baked into `v5_hpms[]`. Doable but needs validation on multiple SVB-version chips; left for a follow-up.
- **APHY SSC block** (CRG+0x1A0 area, much richer bitfield map in the u-boot patch) — separate spread-spectrum module attached to the ethernet APHY, not part of HPM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)