### PR TITLE
mtd: fix use-after-free in find_ubi_for_mtd (segfault on musl arm64)

### DIFF
--- a/src/mtd.c
+++ b/src/mtd.c
@@ -125,6 +125,7 @@ int find_ubi_for_mtd(int mtd_num) {
     DIR *d = opendir("/sys/class/ubi");
     if (!d)
         return -1;
+    int ubi_num = -1;
     struct dirent *de;
     while ((de = readdir(d))) {
         if (strncmp(de->d_name, "ubi", 3) != 0)
@@ -134,20 +135,23 @@ int find_ubi_for_mtd(int mtd_num) {
         char path[128];
         snprintf(path, sizeof(path), "/sys/class/ubi/%s/mtd_num", de->d_name);
         FILE *f = fopen(path, "r");
-        if (f) {
-            int num;
-            if (fscanf(f, "%d", &num) == 1 && num == mtd_num) {
-                fclose(f);
-                closedir(d);
-                int ubi_num;
-                sscanf(de->d_name, "ubi%d", &ubi_num);
-                return ubi_num;
-            }
-            fclose(f);
+        if (!f)
+            continue;
+        int num;
+        bool match = fscanf(f, "%d", &num) == 1 && num == mtd_num;
+        fclose(f);
+        if (match) {
+            /* Parse the number BEFORE closedir(): POSIX leaves the
+             * dirent invalid after closedir, and musl actively
+             * invalidates it (where glibc happens to keep it alive),
+             * so reading de->d_name after closedir is a segfault on
+             * the aarch64 musl build. */
+            sscanf(de->d_name, "ubi%d", &ubi_num);
+            break;
         }
     }
     closedir(d);
-    return -1;
+    return ubi_num;
 }
 
 int enum_ubi_volumes(int ubi_num, ubi_vol_info_t *vols, int max_vols) {


### PR DESCRIPTION
Found while validating the arm64 release binary on a Hi3519DV500 board: the published `ipctool-arm64` (Bootlin musl static) segfaults with `exit 139` immediately after detection, but only on `ipctool` (full YAML); subcommands like `-c`, `-s`, `clocks` all work.

## The bug

`find_ubi_for_mtd()` reads `de->d_name` after `closedir(d)`:

```c
closedir(d);
int ubi_num;
sscanf(de->d_name, "ubi%d", &ubi_num);   // de invalid after closedir
return ubi_num;
```

POSIX explicitly leaves `struct dirent` invalid after `closedir()`. glibc happens to keep the buffer alive across the close (so the bug never surfaced on the old arm32/mips32 release artifacts or on the local glibc dev build); musl invalidates it immediately, which is what the published Bootlin-musl arm64 binary hits.

## Reproduction

Bisected `build_yaml()` → `get_mtd_info` → `cb_mtd_info` → `find_ubi_for_mtd(4)`:

```
[fub] dirent='ubi0'
[fub] fopen /sys/class/ubi/ubi0/mtd_num
[fub] fscanf ret=1 num=4
Segmentation fault
```

`num=4` matches `mtd_num=4` (the rootfs ubifs volume), so the function enters the "match" branch where it closes the dir and then derefs `de`. Local repro with `/opt/aarch64--musl--stable-2025.08-1/bin/aarch64-buildroot-linux-musl-gcc` confirms the same crash; glibc-built binary doesn't.

## Fix

Restructure to parse `de->d_name` **before** `closedir()` with a single local `ubi_num` initialised to -1 returned at the end. Same control-flow shape (early `continue` on fopen failure) so the diff stays small.

## Test plan

- [x] Bootlin-musl arm64 build now produces full YAML on Hi3519DV500 (was: exit 139)
- [x] CI green on arm32 / mips32 / arm64 matrix
- [x] No behavioural change on glibc/arm32/mips32 — same UBI lookup result, only the memory accesses are reordered

## Impact

The currently published `ipctool-arm64` at `latest` is broken on bare invocation. Merging this and letting the release workflow re-publish closes the regression. The pre-merge state of `master` (after #168, #169, #170) does *not* exhibit the bug on the glibc dev build we used to validate V5 earlier — only the musl-built release artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)