### PR TITLE
hal/hisi: fix strcpy-param-overlap in get_hisi_sdk (UB, caught by ASAN)

### DIFF
--- a/src/hal/hisi/hal_hisi.c
+++ b/src/hal/hisi/hal_hisi.c
@@ -474,7 +474,12 @@ static void get_hisi_sdk(cJSON *j_inner) {
             return;
         *ptr++ = ' ';
         *ptr++ = '(';
-        strcpy(ptr, build + 1);
+        /* build+1 and ptr alias the same buffer (the bracketed build
+         * time sits after the ']' we just overwrote), so this is an
+         * overlapping copy: strcpy() is UB here (ASAN: strcpy-param-
+         * overlap), memmove() is well-defined and yields the same
+         * "<version> (<build time>)" string. */
+        memmove(ptr, build + 1, strlen(build + 1) + 1);
         strcat(ptr, ")");
         ADD_PARAM("sdk", buf);
     }


### PR DESCRIPTION
## What

`get_hisi_sdk()` reformats the `/proc/umap/sys` version line into `"<version> (<build time>)"`. Because `line_from_file()` returns the **greedy** capture of `Version: \[(.+)\]`, a typical Hisilicon line like:

```
[SYS] Version: [Hi3516CV500_MPP_V2.0.2.1 B030 Release], Build Time[May 28 2020, 11:04:35]
```

leaves `buf` spanning **both** brackets. The code overwrites the first `]` with `" ("` and then splices the build time in with:

```c
strcpy(ptr, build + 1);   // build+1 and ptr alias the same buffer
```

`build + 1` and `ptr` point into the **same** `buf`, so this is an **overlapping** `strcpy` — undefined behaviour. It only happens to produce the right string on glibc because the copy direction reads-before-writes; AddressSanitizer aborts on it (`strcpy-param-overlap`), and a different libc/arch could silently corrupt the string.

## Fix

Use `memmove()`, which is well-defined for overlapping ranges and yields the identical output.

## How it was found / verified

Running an ASAN-instrumented build on a live **Hi3516CV500** (glibc) camera aborted here:

```
ERROR: AddressSanitizer: strcpy-param-overlap ...
    #1 get_hisi_sdk  src/hal/hisi/hal_hisi.c:477
    #2 detect_firmare #3 build_yaml #4 main
```

After the fix, the full run completes **ASAN-clean** (exit 0) and the value is unchanged:

```
sdk: "Hi3516CV500_MPP_V2.0.2.1 B030 Release (May 28 2020, 11:04:35)"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)