### PR TITLE
ci(release): make the Telegram binary notification non-blocking

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,6 +155,10 @@ jobs:
 
       - name: Send binary to Telegram
         if: steps.build.outcome == 'success'
+        # A notification timing out (curl exit 28 against api.telegram.org)
+        # must never fail a release whose build succeeded and whose assets
+        # already uploaded — keep it advisory.
+        continue-on-error: true
         env:
           TG_TOKEN: ${{ secrets.TELEGRAM_TOKEN_BOT_OPENIPC }}
           TG_CHANNEL: ${{ secrets.TELEGRAM_CHANNEL_OPENIPC_DEV }}


### PR DESCRIPTION
## Problem

The `ipctool-release` run on `master` (commit `e7a0098`, the get_hisi_sdk fix) failed **despite every build target compiling and both assets uploading**. The only hard failure was the **Send binary to Telegram** step:

```
curl ... https://api.telegram.org/bot.../sendDocument ...
##[error]Process completed with exit code 28      # curl --max-time 15 timeout
```

Unlike the surrounding `Build sources` and `Create release` steps (both `continue-on-error: true`), that notification step had no `continue-on-error`, so a flaky/slow Telegram endpoint gated the whole release.

## Fix

Add `continue-on-error: true` to **Send binary to Telegram** — a notification is advisory and must not fail a release whose build succeeded and whose assets already uploaded.

## Not changed

The `Create release` step still emits a non-fatal `Validation Failed … already_exists … tag_name` annotation because all three matrix targets race to create the same `latest` tag. It is already `continue-on-error: true`, so it does **not** fail the run — left as-is (a proper fix would split release-creation into a single pre-job, out of scope here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)