### PR TITLE
ci(release): create the release once in a pre-job (kill the tag race)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,75 @@ on:
       - 'v*'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
+  # Create (or reuse) the GitHub release exactly once, before the build
+  # matrix fans out. Previously every matrix target ran create-release
+  # against the same tag, so all but the first failed with
+  # "Validation Failed: already_exists / tag_name". Hoisting it into a
+  # single pre-job removes that race; using a gh-CLI upsert (view-or-create)
+  # also means an existing rolling `latest` dev release is reused silently
+  # instead of erroring on every subsequent build.
+  release:
+    runs-on: ubuntu-latest
+    outputs:
+      tag_name: ${{ steps.vars.outputs.tag_name }}
+      git_hash: ${{ steps.vars.outputs.git_hash }}
+      branch_name: ${{ steps.vars.outputs.branch_name }}
+      head_tag: ${{ steps.vars.outputs.head_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute release vars
+        id: vars
+        run: |
+          HEAD_TAG=$(git tag --points-at HEAD)
+          GIT_HASH=$(git rev-parse --short $GITHUB_SHA)
+          BRANCH_NAME=$(echo $GITHUB_REF | cut -d'/' -f 3)
+          if [ -z "$HEAD_TAG" ]; then
+            TAG_NAME="latest"
+            RELEASE_NAME="Development Build"
+            PRERELEASE=true
+          else
+            TAG_NAME=${GITHUB_REF}
+            RELEASE_NAME="Release ${GITHUB_REF}"
+            PRERELEASE=false
+          fi
+          {
+            echo "head_tag=$HEAD_TAG"
+            echo "git_hash=$GIT_HASH"
+            echo "branch_name=$BRANCH_NAME"
+            echo "tag_name=$TAG_NAME"
+            echo "release_name=$RELEASE_NAME"
+            echo "prerelease=$PRERELEASE"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Ensure release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG_NAME: ${{ steps.vars.outputs.tag_name }}
+          RELEASE_NAME: ${{ steps.vars.outputs.release_name }}
+          PRERELEASE: ${{ steps.vars.outputs.prerelease }}
+          GIT_HASH: ${{ steps.vars.outputs.git_hash }}
+        run: |
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            echo "Release '$TAG_NAME' already exists — reusing it."
+          else
+            FLAGS=()
+            [ "$PRERELEASE" = "true" ] && FLAGS+=(--prerelease)
+            gh release create "$TAG_NAME" \
+              --title "$RELEASE_NAME" \
+              --notes "Automated build of $GIT_HASH" \
+              --target "$GITHUB_SHA" \
+              "${FLAGS[@]}"
+          fi
+
   build:
+    needs: release
     runs-on: ubuntu-latest
 
     strategy:
@@ -42,32 +109,15 @@ jobs:
 
     env:
       UPX_VERSION: 4.2.3
+      TAG_NAME: ${{ needs.release.outputs.tag_name }}
+      GIT_HASH: ${{ needs.release.outputs.git_hash }}
+      BRANCH_NAME: ${{ needs.release.outputs.branch_name }}
+      HEAD_TAG: ${{ needs.release.outputs.head_tag }}
 
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Compute release vars
-        run: |
-          HEAD_TAG=$(git tag --points-at HEAD)
-          GIT_HASH=$(git rev-parse --short $GITHUB_SHA)
-          BRANCH_NAME=$(echo $GITHUB_REF | cut -d'/' -f 3)
-          if [ -z "$HEAD_TAG" ]; then
-            TAG_NAME="latest"
-            RELEASE_NAME="Development Build"
-            PRERELEASE=true
-          else
-            TAG_NAME=${GITHUB_REF}
-            RELEASE_NAME="Release ${GITHUB_REF}"
-            PRERELEASE=false
-          fi
-          echo "HEAD_TAG=$HEAD_TAG"         >> $GITHUB_ENV
-          echo "GIT_HASH=$GIT_HASH"         >> $GITHUB_ENV
-          echo "BRANCH_NAME=$BRANCH_NAME"   >> $GITHUB_ENV
-          echo "TAG_NAME=$TAG_NAME"         >> $GITHUB_ENV
-          echo "RELEASE_NAME=$RELEASE_NAME" >> $GITHUB_ENV
-          echo "PRERELEASE=$PRERELEASE"     >> $GITHUB_ENV
 
       - name: Fetch toolchain
         run: |
@@ -108,18 +158,6 @@ jobs:
           TG_HEADER=$(echo -e "\r\n$TG_NOTIFY \r\n\r\nCommit: $GIT_HASH \r\nBranch: $BRANCH_NAME \r\nTag: $TAG_NAME \r\n\r\n\xE2\x9A\xA0 GitHub Actions")
           curl $TG_OPTIONS -H "Content-Type: multipart/form-data" -X POST https://api.telegram.org/bot$TG_TOKEN/sendMessage \
             -F chat_id=$TG_CHANNEL -F text="$TG_HEADER"
-
-      - name: Create release
-        if: steps.build.outcome == 'success'
-        uses: actions/create-release@v1
-        continue-on-error: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.TAG_NAME }}
-          release_name: ${{ env.RELEASE_NAME }}
-          draft: false
-          prerelease: ${{ env.PRERELEASE }}
 
       - name: Upload ipctool to release
         if: steps.build.outcome == 'success'


### PR DESCRIPTION
## Problem

All three matrix targets (`arm32` / `mips32` / `arm64`) ran `actions/create-release@v1` against the **same** tag, so the two that lost the race logged:

```
Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
```

on every run. It was non-fatal (`continue-on-error`) after #174, but noisy and confusing in the run annotations.

## Change

Hoist release creation into a single **`release` pre-job** that the `build` matrix `needs:`:

- Computes the release vars **once** and exposes them as job outputs (`tag_name` / `git_hash` / `branch_name` / `head_tag`).
- Ensures the release exists with a **`gh` CLI upsert** (`gh release view … || gh release create …`) instead of the deprecated `actions/create-release@v1` — so an existing rolling `latest` dev release is **reused silently** rather than erroring.
- Asset upload and the advisory Telegram notification stay per-target in the `build` matrix.

Also adds an explicit `permissions: contents: write` so release creation and asset upload don't rely on the repo's default token permissions.

## No behavioural change to artifacts

Assets are still uploaded with `overwrite: true`, and the `latest` tag still points where it did before (the pre-job reuses an existing release without moving the ref).

Validated locally with `actionlint` (clean) + YAML parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)