### PR TITLE
ci: bump actions/checkout v4 -> v5 (clear Node 20 deprecation)

### DIFF
--- a/.github/workflows/pr-build-check.yml
+++ b/.github/workflows/pr-build-check.yml
@@ -27,7 +27,7 @@ jobs:
             toolchain_dir: aarch64--musl--stable-2025.08-1
             cc: aarch64-buildroot-linux-musl-gcc
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Fetch toolchain
         run: |
           # Download to file (with retries) before extracting — piping
@@ -49,6 +49,6 @@ jobs:
     name: Test sensor extraction pipeline
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run end-to-end pipeline smoke test
         run: tools/test_pipeline.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       branch_name: ${{ steps.vars.outputs.branch_name }}
       head_tag: ${{ steps.vars.outputs.head_tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -115,7 +115,7 @@ jobs:
       HEAD_TAG: ${{ needs.release.outputs.head_tag }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## Why

`actions/checkout@v4` runs on the **deprecated Node 20** runtime; GitHub now force-runs it on Node 24 and emits a deprecation warning on every job (visible in recent `ipctool-release` runs):

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4
```

## Change

Bump all `actions/checkout` uses `@v4` → `@v5` (Node 24 native) in the tracked workflows: `release.yml` (×2) and `pr-build-check.yml` (×2).

Third-party actions (`svenstaro/upload-release-action`, `tpaschalis/s3-sync-action`, `appleboy/ssh-action`) are left as-is — they're not the `actions/*` Node-20 source flagged here.

Validated with `actionlint` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)